### PR TITLE
feat(persister): Cache recordings

### DIFF
--- a/docs/persisters/custom.md
+++ b/docs/persisters/custom.md
@@ -29,8 +29,6 @@ yarn add @pollyjs/persister -D
 import Persister from '@pollyjs/persister';
 
 class CustomPersister extends Persister {
-  findRecordingEntry() {}
-
   findRecording() {}
 
   saveRecording() {}

--- a/packages/@pollyjs/adapter/src/index.js
+++ b/packages/@pollyjs/adapter/src/index.js
@@ -119,9 +119,7 @@ export default class Adapter {
 
   async replay(pollyRequest) {
     const { config } = this.polly;
-    const recordingEntry = await this.persister.findRecordingEntry(
-      pollyRequest
-    );
+    const recordingEntry = await this.persister.findEntry(pollyRequest);
 
     if (recordingEntry) {
       await pollyRequest._trigger('beforeReplay', recordingEntry);

--- a/packages/@pollyjs/core/src/persisters/local-storage/index.js
+++ b/packages/@pollyjs/core/src/persisters/local-storage/index.js
@@ -1,5 +1,4 @@
 import Persister from '@pollyjs/persister';
-import get from 'lodash-es/get';
 import stringify from 'json-stable-stringify';
 
 export default class LocalStoragePersister extends Persister {
@@ -17,13 +16,6 @@ export default class LocalStoragePersister extends Persister {
 
   set db(db) {
     this._store.setItem(this._namespace, stringify(db));
-  }
-
-  findRecordingEntry(pollyRequest) {
-    const { id, order, recordingId } = pollyRequest;
-    const entries = get(this.db, `${recordingId}.entries.${id}`) || [];
-
-    return entries[order] || null;
   }
 
   findRecording(recordingId) {

--- a/packages/@pollyjs/core/src/persisters/rest/index.js
+++ b/packages/@pollyjs/core/src/persisters/rest/index.js
@@ -10,19 +10,6 @@ export default class RestPersister extends Persister {
     return ajax(buildUrl(host, apiNamespace, url), ...args);
   }
 
-  async findRecordingEntry(pollyRequest) {
-    const { id, order, recordingId } = pollyRequest;
-
-    const response = await this.ajax(
-      `/${encodeURIComponent(recordingId)}/${id}?order=${order}`,
-      {
-        Accept: 'application/json; charset=utf-8'
-      }
-    );
-
-    return this._normalize(response);
-  }
-
   async findRecording(recordingId) {
     const response = await this.ajax(`/${encodeURIComponent(recordingId)}`, {
       Accept: 'application/json; charset=utf-8'

--- a/packages/@pollyjs/core/tests/integration/adapters-test.js
+++ b/packages/@pollyjs/core/tests/integration/adapters-test.js
@@ -58,9 +58,9 @@ describe('Integration | Adapters', function() {
 
         server.get(this.recordUrl()).passthrough();
 
-        expect(await persister.findRecording(recordingId)).to.be.null;
+        expect(await persister.find(recordingId)).to.be.null;
         expect((await this.fetchRecord()).status).to.equal(404);
-        expect(await persister.findRecording(recordingId)).to.be.null;
+        expect(await persister.find(recordingId)).to.be.null;
       });
 
       it('should handle recording requests posting FormData + Blob/File', async function() {

--- a/packages/@pollyjs/core/tests/integration/persisters-test.js
+++ b/packages/@pollyjs/core/tests/integration/persisters-test.js
@@ -13,7 +13,7 @@ describe('Integration | Persisters', function() {
       setupFetch.beforeEach(defaults.adapters[0]);
 
       afterEach(async function() {
-        await this.polly.persister.deleteRecording(this.polly.recordingId);
+        await this.polly.persister.delete(this.polly.recordingId);
       });
 
       setupFetch.afterEach();
@@ -26,7 +26,7 @@ describe('Integration | Persisters', function() {
         await this.fetch('/api/db/foo?order=1');
         await persister.persist();
 
-        const recording = await persister.findRecording(recordingId);
+        const recording = await persister.find(recordingId);
         const entriesKeys = keys(recording.entries);
 
         // Top Level Schema
@@ -81,7 +81,7 @@ describe('Integration | Persisters', function() {
         await this.fetch('/api/db/foo?order=1');
         await persister.persist();
 
-        let savedRecording = await persister.findRecording(recordingId);
+        let savedRecording = await persister.find(recordingId);
         let entryKeys = keys(savedRecording.entries);
 
         expect(entryKeys.length).to.equal(1);
@@ -98,7 +98,7 @@ describe('Integration | Persisters', function() {
         await this.fetch('/api/db/foo?order=2');
         await persister.persist();
 
-        savedRecording = await persister.findRecording(recordingId);
+        savedRecording = await persister.find(recordingId);
         entryKeys = keys(savedRecording.entries).sort();
 
         expect(entryKeys.length).to.equal(2);
@@ -138,7 +138,7 @@ describe('Integration | Persisters', function() {
       setupFetch.beforeEach(defaults.adapters[0]);
 
       afterEach(function() {
-        return this.polly.persister.deleteRecording(this.polly.recordingId);
+        return this.polly.persister.delete(this.polly.recordingId);
       });
 
       setupFetch.afterEach();
@@ -152,7 +152,7 @@ describe('Integration | Persisters', function() {
         } catch (e) {
           error = e;
         } finally {
-          const savedRecording = await this.polly.persister.findRecording(
+          const savedRecording = await this.polly.persister.find(
             this.polly.recordingId
           );
 
@@ -170,7 +170,7 @@ describe('Integration | Persisters', function() {
       setupFetch.beforeEach(defaults.adapters[0]);
 
       afterEach(function() {
-        return this.polly.persister.deleteRecording(this.polly.recordingId);
+        return this.polly.persister.delete(this.polly.recordingId);
       });
 
       setupFetch.afterEach();
@@ -180,7 +180,7 @@ describe('Integration | Persisters', function() {
         await this.fetch('/should-not-exist-also');
         await this.polly.stop();
 
-        const savedRecording = await this.polly.persister.findRecording(
+        const savedRecording = await this.polly.persister.find(
           this.polly.recordingId
         );
 

--- a/packages/@pollyjs/node-server/src/api.js
+++ b/packages/@pollyjs/node-server/src/api.js
@@ -6,21 +6,6 @@ export default class API {
     this.recordingsDir = recordingsDir;
   }
 
-  getRecordingEntry(recording, entryId, order) {
-    const recordingFilename = this.filenameFor(recording);
-
-    if (fs.existsSync(recordingFilename)) {
-      const data = fs.readJsonSync(recordingFilename);
-      const entries = data.entries[entryId];
-
-      if (entries && entries[order]) {
-        return this.respond(200, entries[order]);
-      }
-    }
-
-    return this.respond(204);
-  }
-
   getRecording(recording) {
     const recordingFilename = this.filenameFor(recording);
 

--- a/packages/@pollyjs/node-server/src/express/register-api.js
+++ b/packages/@pollyjs/node-server/src/express/register-api.js
@@ -14,20 +14,6 @@ export default function registerAPI(app, config) {
 
   router.use(nocache());
 
-  router.get('/:recording/:entryId', function(req, res) {
-    const { recording, entryId } = req.params;
-    const { order } = req.query;
-    const { status, body } = api.getRecordingEntry(recording, entryId, order);
-
-    res.status(status);
-
-    if (status === 200) {
-      res.json(body);
-    } else {
-      res.end();
-    }
-  });
-
   router.get('/:recording', function(req, res) {
     const { recording } = req.params;
     const { status, body } = api.getRecording(recording);
@@ -41,10 +27,7 @@ export default function registerAPI(app, config) {
     }
   });
 
-  router.post('/:recording', bodyParser.json({ limit: '50mb' }), function(
-    req,
-    res
-  ) {
+  router.post('/:recording', bodyParser.json(), function(req, res) {
     const { recording } = req.params;
     const { status, body } = api.saveRecording(recording, req.body);
 

--- a/packages/@pollyjs/persister/README.md
+++ b/packages/@pollyjs/persister/README.md
@@ -36,8 +36,6 @@ documentation for more details.
 import Persister from '@pollyjs/persister';
 
 class CustomPersister extends Persister {
-  findRecordingEntry() {}
-
   findRecording() {}
 
   saveRecording() {}

--- a/packages/@pollyjs/persister/tests/unit/persister-test.js
+++ b/packages/@pollyjs/persister/tests/unit/persister-test.js
@@ -1,7 +1,72 @@
-import Adapter from '../../src';
+import Persister from '../../src';
 
-describe('Unit | Adapter', function() {
+describe('Unit | Persister', function() {
   it('should exist', function() {
-    expect(Adapter).to.be.a('function');
+    expect(Persister).to.be.a('function');
+  });
+
+  describe('Caching', function() {
+    let callCounts, recording;
+
+    beforeEach(function() {
+      callCounts = { find: 0, save: 0, delete: 0 };
+      recording = {};
+
+      class CustomPersister extends Persister {
+        findRecording() {
+          callCounts.find++;
+
+          return recording;
+        }
+
+        saveRecording() {
+          callCounts.save++;
+        }
+
+        deleteRecording() {
+          callCounts.delete++;
+        }
+      }
+
+      this.persister = new CustomPersister({});
+    });
+
+    it('caches', async function() {
+      await this.persister.find('test');
+      await this.persister.find('test');
+      await this.persister.find('test');
+
+      expect(callCounts.find).to.equal(1);
+    });
+
+    it('does not cache falsy values', async function() {
+      recording = null;
+
+      await this.persister.find('test');
+      await this.persister.find('test');
+      await this.persister.find('test');
+
+      expect(callCounts.find).to.equal(3);
+    });
+
+    it('busts the cache after a save', async function() {
+      await this.persister.find('test');
+      await this.persister.save('test');
+      await this.persister.find('test');
+      await this.persister.find('test');
+
+      expect(callCounts.save).to.equal(1);
+      expect(callCounts.find).to.equal(2);
+    });
+
+    it('busts the cache after a delete', async function() {
+      await this.persister.find('test');
+      await this.persister.delete('test');
+      await this.persister.find('test');
+      await this.persister.find('test');
+
+      expect(callCounts.delete).to.equal(1);
+      expect(callCounts.find).to.equal(2);
+    });
   });
 });


### PR DESCRIPTION
I realized that we don't really need a `findRecordingEntry` method since we fetch the entire recording when persisting anyways. We might as well cache the recording on the first `find` and use that to locally find entries. This should greatly reduce the amount of network requests we make as well as reduce the amount of times we read from disk.

- Cache recordings and bring `findRecordingEntry` into the base persister.
- Bust the cache when saving & deleting. 