### PR TITLE
fix: Ensure polly's middleware goes before ember-cli's

### DIFF
--- a/packages/@pollyjs/ember/package.json
+++ b/packages/@pollyjs/ember/package.json
@@ -76,6 +76,9 @@
     "node": "6.* || >= 7.*"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "before": [
+      "proxy-server-middleware"
+    ]
   }
 }


### PR DESCRIPTION
This should allow polly to work nicely with ember-cli's when the
`--proxy` option is passed.