### PR TITLE
chore: Tests now run in MS Edge

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-node": "^5.2.1",
     "eslint-plugin-prettier": "^2.6.0",
+    "formdata-polyfill": "^3.0.10",
     "husky": "^0.14.3",
     "lerna": "^2.11.0",
     "lerna-alias": "^3.0.2",
@@ -68,6 +69,6 @@
     "rollup-plugin-node-resolve": "^3.3.0",
     "rollup-plugin-uglify": "^3.0.0",
     "start-server-and-test": "^1.4.1",
-    "testem": "^2.2.1"
+    "testem": "^2.8.2"
   }
 }

--- a/packages/@pollyjs/core/src/server/route.js
+++ b/packages/@pollyjs/core/src/server/route.js
@@ -7,7 +7,7 @@ async function invoke(fn, route, req, ...args) {
         /* NOTE: IE's `Reflect.set` swallows the read-only assignment error */
         /* see: https://codepen.io/jasonmit/pen/LrmLaz */
         source[prop] = value;
-        
+
         return true;
       },
       get(source, prop) {

--- a/packages/@pollyjs/core/src/server/route.js
+++ b/packages/@pollyjs/core/src/server/route.js
@@ -3,13 +3,20 @@ import Handler from './handler';
 async function invoke(fn, route, req, ...args) {
   if (typeof fn === 'function') {
     const proxyReq = new Proxy(req, {
+      set(source, prop, value) {
+        /* NOTE: IE's `Reflect.set` swallows the read-only assignment error */
+        /* see: https://codepen.io/jasonmit/pen/LrmLaz */
+        source[prop] = value;
+        
+        return true;
+      },
       get(source, prop) {
         if (prop === 'params') {
           // Set the request's params to given route's matched params
           return route.params;
         }
 
-        return source[prop];
+        return Reflect.get(source, prop);
       }
     });
 

--- a/packages/@pollyjs/core/tests/helpers/file.js
+++ b/packages/@pollyjs/core/tests/helpers/file.js
@@ -1,0 +1,58 @@
+/**
+ * Special thanks to the FormData project.
+ * Full credit: https://github.com/jimmywarting/FormData (MIT)
+ */
+
+const { defineProperties, defineProperty } = Object;
+const stringTag = Symbol && Symbol.toStringTag;
+
+let _File;
+
+try {
+  new File([], '');
+  _File = File;
+} catch (e) {
+  /**
+   * @see http://www.w3.org/TR/FileAPI/#dfn-file
+   * @param {!Array<string|!Blob|!ArrayBuffer>=} chunks
+   * @param {string=} filename
+   * @param {{type: (string|undefined), lastModified: (number|undefined)}=}
+   *     opts
+   * @constructor
+   * @extends {Blob}
+   */
+  _File = function File(chunks, filename, opts = {}) {
+    const _this = new Blob(chunks, opts);
+    const modified =
+      opts && opts.lastModified !== undefined
+        ? new Date(opts.lastModified)
+        : new Date();
+
+    defineProperties(_this, {
+      name: {
+        value: filename
+      },
+      lastModifiedDate: {
+        value: modified
+      },
+      lastModified: {
+        value: +modified
+      },
+      toString: {
+        value() {
+          return '[object File]';
+        }
+      }
+    });
+
+    if (stringTag) {
+      defineProperty(_this, Symbol.toStringTag, {
+        value: 'File'
+      });
+    }
+    
+    return _this;
+  };
+}
+
+export default _File;

--- a/packages/@pollyjs/core/tests/helpers/file.js
+++ b/packages/@pollyjs/core/tests/helpers/file.js
@@ -50,7 +50,7 @@ try {
         value: 'File'
       });
     }
-    
+
     return _this;
   };
 }

--- a/packages/@pollyjs/core/tests/integration/adapters-test.js
+++ b/packages/@pollyjs/core/tests/integration/adapters-test.js
@@ -1,5 +1,8 @@
+import 'formdata-polyfill';
+
 import { setupMocha as setupPolly } from '../../src';
 import * as setupFetch from '../helpers/setup-fetch';
+import File from '../helpers/file';
 import Configs from './configs';
 
 const { parse } = JSON;

--- a/packages/@pollyjs/core/tests/unit/utils/serialize-request-body-test.js
+++ b/packages/@pollyjs/core/tests/unit/utils/serialize-request-body-test.js
@@ -1,4 +1,5 @@
 import serializeRequestBody from '../../../src/utils/serialize-request-body';
+import File from '../../helpers/file';
 
 describe('Unit | Utils | serializeRequestBody', function() {
   it('should exist', function() {

--- a/test/index.mustache
+++ b/test/index.mustache
@@ -27,6 +27,14 @@
 
     <script>
         mocha.checkLeaks();
+        mocha.globals([
+          /**
+           * The follow globals are inserted by Internet Explorer's developer tools.
+           * IE injects these into the running context for debugging.
+           * This confuses mocha and it thinks it's observing a memory leak between runs.
+           */
+          '$0', '$1', '$2', '$3', '$4', '$_', '__BROWSERTOOLS_DOMEXPLORER_ADDED'
+        ]);
         mocha.run();
     </script>
   </body>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1426,9 +1426,9 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
 
-consolidate@^0.14.0:
-  version "0.14.5"
-  resolved "https://registry.yarnpkg.com/consolidate/-/consolidate-0.14.5.tgz#5a25047bc76f73072667c8cb52c989888f494c63"
+consolidate@^0.15.1:
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/consolidate/-/consolidate-0.15.1.tgz#21ab043235c71a07d45d9aad98593b0dba56bab7"
   dependencies:
     bluebird "^3.1.1"
 
@@ -2463,6 +2463,10 @@ form-data@~2.3.1:
     asynckit "^0.4.0"
     combined-stream "1.0.6"
     mime-types "^2.1.12"
+
+formdata-polyfill@^3.0.10:
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-3.0.10.tgz#4e1bfcc1e131f73b07856fc159ee103d0b37ec3c"
 
 forwarded@~0.1.2:
   version "0.1.2"
@@ -4000,6 +4004,13 @@ minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
+minipass@^2.2.0:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.3.tgz#a7dcc8b7b833f5d368759cce544dccb55f50f233"
+  dependencies:
+    safe-buffer "^5.1.2"
+    yallist "^3.0.0"
+
 mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.1, mkdirp@~0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
@@ -4505,9 +4516,9 @@ prettier@^1.12.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.12.0.tgz#d26fc5894b9230de97629b39cae225b503724ce8"
 
-printf@^0.2.3:
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/printf/-/printf-0.2.5.tgz#c438ca2ca33e3927671db4ab69c0e52f936a4f0f"
+printf@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/printf/-/printf-0.3.0.tgz#6918ca5237c047e19cf004b69e6bcfafbef1ce82"
 
 prismjs@^1.9.0:
   version "1.14.0"
@@ -4688,7 +4699,7 @@ readable-stream@^1.0.26-4:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@^2, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2:
+readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   dependencies:
@@ -5046,6 +5057,10 @@ rx@^4.1.0:
 safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
+
+safe-buffer@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
 
 safer-buffer@^2.1.0:
   version "2.1.2"
@@ -5466,14 +5481,13 @@ table@4.0.2:
     slice-ansi "1.0.0"
     string-width "^2.1.1"
 
-tap-parser@^5.1.0:
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/tap-parser/-/tap-parser-5.4.0.tgz#6907e89725d7b7fa6ae41ee2c464c3db43188aec"
+tap-parser@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/tap-parser/-/tap-parser-7.0.0.tgz#54db35302fda2c2ccc21954ad3be22b2cba42721"
   dependencies:
     events-to-array "^1.0.1"
     js-yaml "^3.2.7"
-  optionalDependencies:
-    readable-stream "^2"
+    minipass "^2.2.0"
 
 tar-pack@^3.4.0:
   version "3.4.1"
@@ -5524,15 +5538,15 @@ term-size@^1.2.0:
   dependencies:
     execa "^0.7.0"
 
-testem@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/testem/-/testem-2.2.1.tgz#7bcda44eeb34287d918b3c8b9c6863d26a616557"
+testem@^2.8.2:
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/testem/-/testem-2.8.2.tgz#0d51801cbcdfe411e2e24ae7e63e2eca779dfe89"
   dependencies:
     backbone "^1.1.2"
     bluebird "^3.4.6"
     charm "^1.0.0"
     commander "^2.6.0"
-    consolidate "^0.14.0"
+    consolidate "^0.15.1"
     execa "^0.10.0"
     express "^4.10.7"
     fireworm "^0.7.0"
@@ -5548,12 +5562,12 @@ testem@^2.2.1:
     mustache "^2.2.1"
     node-notifier "^5.0.1"
     npmlog "^4.0.0"
-    printf "^0.2.3"
+    printf "^0.3.0"
     rimraf "^2.4.4"
     socket.io "^2.1.0"
     spawn-args "^0.2.0"
     styled_string "0.0.1"
-    tap-parser "^5.1.0"
+    tap-parser "^7.0.0"
     xmldom "^0.1.19"
 
 text-extensions@^1.0.0:
@@ -5948,6 +5962,10 @@ y18n@^3.2.1:
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+
+yallist@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.2.tgz#8452b4bb7e83c7c188d8041c1a837c773d6d8bb9"
 
 yargonaut@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
This PR does not include the changes to rollup since I consider that separate for Edge support.  IE 11 is a bit more work, but I have most of that done in another branch just need to verify it.

I'll probably introduce a test:legacy command since it's going to slow the build down a bit and make normal debugging in modern browsers difficult.

One of two changes required for #28