### PR TITLE
fix: If the source URL is relative the normalized must not have domain

### DIFF
--- a/packages/@pollyjs/core/package.json
+++ b/packages/@pollyjs/core/package.json
@@ -51,6 +51,7 @@
     "@pollyjs/utils": "^0.1.0",
     "@sindresorhus/fnv1a": "^1.0.0",
     "blueimp-md5": "^2.10.0",
+    "is-absolute-url": "^2.1.0",
     "json-stable-stringify": "^1.0.1",
     "lodash-es": "^4.17.10",
     "merge-options": "^1.0.1",

--- a/packages/@pollyjs/core/src/-private/request.js
+++ b/packages/@pollyjs/core/src/-private/request.js
@@ -5,6 +5,7 @@ import PollyResponse from './response';
 import NormalizeRequest from '../utils/normalize-request';
 import removeHostFromUrl from '../utils/remove-host-from-url';
 import serializeRequestBody from '../utils/serialize-request-body';
+import isAbsoluteUrl from 'is-absolute-url';
 import { assert, timestamp } from '@pollyjs/utils';
 
 const { keys, freeze } = Object;
@@ -47,11 +48,11 @@ export default class PollyRequest {
     const url = new URL(value, true);
 
     /*
-      If the url starts with a '/', setup the parsed url to reflect just that
+      If the url is relative, setup the parsed url to reflect just that
       by removing the host. By default URL sets the host via window.location if
       it does not exist.
     */
-    if (value.startsWith('/')) {
+    if (!isAbsoluteUrl(value)) {
       removeHostFromUrl(url);
     }
 

--- a/packages/@pollyjs/core/src/utils/normalize-request.js
+++ b/packages/@pollyjs/core/src/utils/normalize-request.js
@@ -1,21 +1,23 @@
 import URL from 'url-parse';
 import removeHostFromUrl from './remove-host-from-url';
 import isObjectLike from 'lodash-es/isObjectLike';
+import isAbsoluteUrl from 'is-absolute-url';
 
 const { keys } = Object;
-
-function isAbsoluteUrl(url) {
-  /^[a-z][a-z0-9+.-]*:/.test(url);
-}
 
 export function method(method) {
   return (method || 'GET').toUpperCase();
 }
 
 export function url(url, config = {}) {
-  let isRelative = !isAbsoluteUrl(url);
   const parsedUrl = new URL(url, true);
 
+  // Remove the host if the url is relative
+  if (!isAbsoluteUrl(url)) {
+    removeHostFromUrl(parsedUrl);
+  }
+
+  // Remove any url properties that have been disabled via the config
   keys(config).forEach(key => !config[key] && parsedUrl.set(key, ''));
 
   // Sort Query Params
@@ -33,9 +35,6 @@ export function url(url, config = {}) {
     parsedUrl.set('query', sortedQuery);
   }
 
-  if (isRelative) {
-    return removeHostFromUrl(parsedUrl);
-  }
   return parsedUrl.href;
 }
 

--- a/packages/@pollyjs/core/src/utils/normalize-request.js
+++ b/packages/@pollyjs/core/src/utils/normalize-request.js
@@ -1,13 +1,19 @@
 import URL from 'url-parse';
+import removeHostFromUrl from './remove-host-from-url';
 import isObjectLike from 'lodash-es/isObjectLike';
 
 const { keys } = Object;
+
+function isAbsoluteUrl(url) {
+  /^[a-z][a-z0-9+.-]*:/.test(url);
+}
 
 export function method(method) {
   return (method || 'GET').toUpperCase();
 }
 
 export function url(url, config = {}) {
+  let isRelative = !isAbsoluteUrl(url);
   const parsedUrl = new URL(url, true);
 
   keys(config).forEach(key => !config[key] && parsedUrl.set(key, ''));
@@ -27,6 +33,9 @@ export function url(url, config = {}) {
     parsedUrl.set('query', sortedQuery);
   }
 
+  if (isRelative) {
+    return removeHostFromUrl(parsedUrl);
+  }
   return parsedUrl.href;
 }
 

--- a/packages/@pollyjs/core/tests/integration/persisters-test.js
+++ b/packages/@pollyjs/core/tests/integration/persisters-test.js
@@ -102,8 +102,8 @@ describe('Integration | Persisters', function() {
         entryKeys = keys(savedRecording.entries).sort();
 
         expect(entryKeys.length).to.equal(2);
-        expect(savedRecording.entries[entryKeys[0]].length).to.equal(2);
-        expect(savedRecording.entries[entryKeys[1]].length).to.equal(1);
+        expect(savedRecording.entries[entryKeys[0]].length).to.equal(1);
+        expect(savedRecording.entries[entryKeys[1]].length).to.equal(2);
       });
 
       it('should emit beforePersist', async function() {

--- a/packages/@pollyjs/core/tests/unit/utils/normalize-request-test.js
+++ b/packages/@pollyjs/core/tests/unit/utils/normalize-request-test.js
@@ -89,5 +89,9 @@ describe('Unit | Utils | Normalize Request', function() {
         });
       });
     });
+
+    it('should not add a domain to relative urls', function() {
+      expect(url('/some/path')).to.equal('/some/path');
+    });
   });
 });

--- a/packages/@pollyjs/core/tests/unit/utils/normalize-request-test.js
+++ b/packages/@pollyjs/core/tests/unit/utils/normalize-request-test.js
@@ -90,7 +90,7 @@ describe('Unit | Utils | Normalize Request', function() {
       });
     });
 
-    it('should not add a domain to relative urls', function() {
+    it('should respect relative urls', function() {
       expect(url('/some/path')).to.equal('/some/path');
     });
   });

--- a/packages/@pollyjs/core/yarn.lock
+++ b/packages/@pollyjs/core/yarn.lock
@@ -529,6 +529,10 @@ inquirer@^3.0.6:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
+is-absolute-url@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-absolute-url/-/is-absolute-url-2.1.0.tgz#50530dfb84fcc9aa7dbe7852e83a37b93b9f2aa6"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"

--- a/test/recordings/-pollyjs_2160168770/core_3713949822/Integration-Adapters_529408267/Fetch-Adapter-Rest-Persister_112800326/should-respect-request-order_2914185093/recording.json
+++ b/test/recordings/-pollyjs_2160168770/core_3713949822/Integration-Adapters_529408267/Fetch-Adapter-Rest-Persister_112800326/should-respect-request-order_2914185093/recording.json
@@ -1,38 +1,16 @@
 {
-  "created_at": "2018-06-01T20:36:46.398Z",
+  "created_at": "2018-06-22T18:07:44.447Z",
   "entries": {
-    "38cf4fab771658dccbdf659232d7cdbb": [
+    "1ee5aa1bce525fe324cd2410440a9e87": [
       {
-        "created_at": "2018-06-01T20:36:46.398Z",
-        "request": {
-          "headers": {},
-          "method": "DELETE",
-          "timestamp": "2018-06-01T20:36:46.374Z",
-          "url": "/api/db/-pollyjs_2160168770%2Fcore_3713949822%2FIntegration-Adapters_529408267%2FFetch-Adapter-Rest-Persister_112800326%2Fshould-respect-request-order_2914185093"
-        },
-        "response": {
-          "body": "",
-          "headers": {
-            "connection": "close",
-            "content-length": "0",
-            "date": "Fri, 01 Jun 2018 20:36:46 GMT",
-            "x-powered-by": "Express"
-          },
-          "status": 200,
-          "timestamp": "2018-06-01T20:36:46.384Z"
-        }
-      }
-    ],
-    "830e91d55341a9824baa79d9707b1943": [
-      {
-        "created_at": "2018-06-01T20:36:46.398Z",
+        "created_at": "2018-06-22T18:07:44.447Z",
         "request": {
           "body": "{\"foo\":\"bar\"}",
           "headers": {
             "Content-Type": "application/json"
           },
           "method": "POST",
-          "timestamp": "2018-06-01T20:36:46.346Z",
+          "timestamp": "2018-06-22T18:07:44.383Z",
           "url": "/api/db/-pollyjs_2160168770%2Fcore_3713949822%2FIntegration-Adapters_529408267%2FFetch-Adapter-Rest-Persister_112800326%2Fshould-respect-request-order_2914185093"
         },
         "response": {
@@ -41,22 +19,22 @@
             "connection": "close",
             "content-length": "13",
             "content-type": "application/json; charset=utf-8",
-            "date": "Fri, 01 Jun 2018 20:36:46 GMT",
+            "date": "Fri, 22 Jun 2018 18:07:44 GMT",
             "etag": "W/\"d-pedE0BZFQNM7HX6mFsKPL6l+dUo\"",
             "x-powered-by": "Express"
           },
           "status": 200,
-          "timestamp": "2018-06-01T20:36:46.358Z"
+          "timestamp": "2018-06-22T18:07:44.394Z"
         }
       }
     ],
-    "a43ff0681a6b74bc1c80068a4fedd5f4": [
+    "be0c42471e72afba776de36e2a1ff59f": [
       {
-        "created_at": "2018-06-01T20:36:46.398Z",
+        "created_at": "2018-06-22T18:07:44.447Z",
         "request": {
           "headers": {},
           "method": "GET",
-          "timestamp": "2018-06-01T20:36:46.334Z",
+          "timestamp": "2018-06-22T18:07:44.372Z",
           "url": "/api/db/-pollyjs_2160168770%2Fcore_3713949822%2FIntegration-Adapters_529408267%2FFetch-Adapter-Rest-Persister_112800326%2Fshould-respect-request-order_2914185093"
         },
         "response": {
@@ -64,19 +42,19 @@
           "headers": {
             "connection": "close",
             "content-length": "0",
-            "date": "Fri, 01 Jun 2018 20:36:46 GMT",
+            "date": "Fri, 22 Jun 2018 18:07:44 GMT",
             "x-powered-by": "Express"
           },
           "status": 404,
-          "timestamp": "2018-06-01T20:36:46.345Z"
+          "timestamp": "2018-06-22T18:07:44.382Z"
         }
       },
       {
-        "created_at": "2018-06-01T20:36:46.398Z",
+        "created_at": "2018-06-22T18:07:44.447Z",
         "request": {
           "headers": {},
           "method": "GET",
-          "timestamp": "2018-06-01T20:36:46.359Z",
+          "timestamp": "2018-06-22T18:07:44.396Z",
           "url": "/api/db/-pollyjs_2160168770%2Fcore_3713949822%2FIntegration-Adapters_529408267%2FFetch-Adapter-Rest-Persister_112800326%2Fshould-respect-request-order_2914185093"
         },
         "response": {
@@ -85,20 +63,20 @@
             "connection": "close",
             "content-length": "13",
             "content-type": "application/json; charset=utf-8",
-            "date": "Fri, 01 Jun 2018 20:36:46 GMT",
+            "date": "Fri, 22 Jun 2018 18:07:44 GMT",
             "etag": "W/\"d-pedE0BZFQNM7HX6mFsKPL6l+dUo\"",
             "x-powered-by": "Express"
           },
           "status": 200,
-          "timestamp": "2018-06-01T20:36:46.372Z"
+          "timestamp": "2018-06-22T18:07:44.408Z"
         }
       },
       {
-        "created_at": "2018-06-01T20:36:46.398Z",
+        "created_at": "2018-06-22T18:07:44.447Z",
         "request": {
           "headers": {},
           "method": "GET",
-          "timestamp": "2018-06-01T20:36:46.385Z",
+          "timestamp": "2018-06-22T18:07:44.429Z",
           "url": "/api/db/-pollyjs_2160168770%2Fcore_3713949822%2FIntegration-Adapters_529408267%2FFetch-Adapter-Rest-Persister_112800326%2Fshould-respect-request-order_2914185093"
         },
         "response": {
@@ -106,11 +84,33 @@
           "headers": {
             "connection": "close",
             "content-length": "0",
-            "date": "Fri, 01 Jun 2018 20:36:46 GMT",
+            "date": "Fri, 22 Jun 2018 18:07:44 GMT",
             "x-powered-by": "Express"
           },
           "status": 404,
-          "timestamp": "2018-06-01T20:36:46.394Z"
+          "timestamp": "2018-06-22T18:07:44.438Z"
+        }
+      }
+    ],
+    "c15804732a62a96170bbda3629b07ba4": [
+      {
+        "created_at": "2018-06-22T18:07:44.447Z",
+        "request": {
+          "headers": {},
+          "method": "DELETE",
+          "timestamp": "2018-06-22T18:07:44.410Z",
+          "url": "/api/db/-pollyjs_2160168770%2Fcore_3713949822%2FIntegration-Adapters_529408267%2FFetch-Adapter-Rest-Persister_112800326%2Fshould-respect-request-order_2914185093"
+        },
+        "response": {
+          "body": "",
+          "headers": {
+            "connection": "close",
+            "content-length": "0",
+            "date": "Fri, 22 Jun 2018 18:07:44 GMT",
+            "x-powered-by": "Express"
+          },
+          "status": 200,
+          "timestamp": "2018-06-22T18:07:44.427Z"
         }
       }
     ]

--- a/test/recordings/-pollyjs_2160168770/core_3713949822/Integration-Adapters_529408267/XHR-Adapter-Rest-Persister_3659812972/should-respect-request-order_2914185093/recording.json
+++ b/test/recordings/-pollyjs_2160168770/core_3713949822/Integration-Adapters_529408267/XHR-Adapter-Rest-Persister_3659812972/should-respect-request-order_2914185093/recording.json
@@ -1,16 +1,16 @@
 {
-  "created_at": "2018-06-01T20:36:46.198Z",
+  "created_at": "2018-06-22T18:07:44.277Z",
   "entries": {
-    "1077f062f8b12b51733933f86fb7ebc4": [
+    "9208660a18c7a292e9534940083341b0": [
       {
-        "created_at": "2018-06-01T20:36:46.198Z",
+        "created_at": "2018-06-22T18:07:44.286Z",
         "request": {
           "body": "{\"foo\":\"bar\"}",
           "headers": {
             "Content-Type": "application/json;charset=utf-8"
           },
           "method": "POST",
-          "timestamp": "2018-06-01T20:36:46.070Z",
+          "timestamp": "2018-06-22T18:07:44.210Z",
           "url": "/api/db/-pollyjs_2160168770%2Fcore_3713949822%2FIntegration-Adapters_529408267%2FXHR-Adapter-Rest-Persister_3659812972%2Fshould-respect-request-order_2914185093"
         },
         "response": {
@@ -19,24 +19,24 @@
             "connection": "close",
             "content-length": "13",
             "content-type": "application/json; charset=utf-8",
-            "date": "Fri, 01 Jun 2018 20",
+            "date": "Fri, 22 Jun 2018 18",
             "etag": "W/\"d-pedE0BZFQNM7HX6mFsKPL6l+dUo\"",
             "x-powered-by": "Express"
           },
           "status": 200,
-          "timestamp": "2018-06-01T20:36:46.119Z"
+          "timestamp": "2018-06-22T18:07:44.224Z"
         }
       }
     ],
-    "70d74380485b3d40cc52f32a0c49d166": [
+    "e6f2c8956e4eedd0937533b32388c842": [
       {
-        "created_at": "2018-06-01T20:36:46.198Z",
+        "created_at": "2018-06-22T18:07:44.286Z",
         "request": {
           "headers": {
             "Content-Type": "text/plain;charset=utf-8"
           },
           "method": "DELETE",
-          "timestamp": "2018-06-01T20:36:46.165Z",
+          "timestamp": "2018-06-22T18:07:44.250Z",
           "url": "/api/db/-pollyjs_2160168770%2Fcore_3713949822%2FIntegration-Adapters_529408267%2FXHR-Adapter-Rest-Persister_3659812972%2Fshould-respect-request-order_2914185093"
         },
         "response": {
@@ -44,23 +44,23 @@
           "headers": {
             "connection": "close",
             "content-length": "0",
-            "date": "Fri, 01 Jun 2018 20",
+            "date": "Fri, 22 Jun 2018 18",
             "x-powered-by": "Express"
           },
           "status": 200,
-          "timestamp": "2018-06-01T20:36:46.179Z"
+          "timestamp": "2018-06-22T18:07:44.260Z"
         }
       }
     ],
-    "a50cd52528f4b6e3ff5502b656c9b296": [
+    "eb39d9b2d7c8db449ab804432be6291a": [
       {
-        "created_at": "2018-06-01T20:36:46.198Z",
+        "created_at": "2018-06-22T18:07:44.286Z",
         "request": {
           "headers": {
             "Content-Type": "text/plain;charset=utf-8"
           },
           "method": "GET",
-          "timestamp": "2018-06-01T20:36:45.979Z",
+          "timestamp": "2018-06-22T18:07:44.188Z",
           "url": "/api/db/-pollyjs_2160168770%2Fcore_3713949822%2FIntegration-Adapters_529408267%2FXHR-Adapter-Rest-Persister_3659812972%2Fshould-respect-request-order_2914185093"
         },
         "response": {
@@ -68,21 +68,21 @@
           "headers": {
             "connection": "close",
             "content-length": "0",
-            "date": "Fri, 01 Jun 2018 20",
+            "date": "Fri, 22 Jun 2018 18",
             "x-powered-by": "Express"
           },
           "status": 404,
-          "timestamp": "2018-06-01T20:36:46.063Z"
+          "timestamp": "2018-06-22T18:07:44.207Z"
         }
       },
       {
-        "created_at": "2018-06-01T20:36:46.198Z",
+        "created_at": "2018-06-22T18:07:44.286Z",
         "request": {
           "headers": {
             "Content-Type": "text/plain;charset=utf-8"
           },
           "method": "GET",
-          "timestamp": "2018-06-01T20:36:46.121Z",
+          "timestamp": "2018-06-22T18:07:44.226Z",
           "url": "/api/db/-pollyjs_2160168770%2Fcore_3713949822%2FIntegration-Adapters_529408267%2FXHR-Adapter-Rest-Persister_3659812972%2Fshould-respect-request-order_2914185093"
         },
         "response": {
@@ -91,22 +91,22 @@
             "connection": "close",
             "content-length": "13",
             "content-type": "application/json; charset=utf-8",
-            "date": "Fri, 01 Jun 2018 20",
+            "date": "Fri, 22 Jun 2018 18",
             "etag": "W/\"d-pedE0BZFQNM7HX6mFsKPL6l+dUo\"",
             "x-powered-by": "Express"
           },
           "status": 200,
-          "timestamp": "2018-06-01T20:36:46.161Z"
+          "timestamp": "2018-06-22T18:07:44.248Z"
         }
       },
       {
-        "created_at": "2018-06-01T20:36:46.198Z",
+        "created_at": "2018-06-22T18:07:44.286Z",
         "request": {
           "headers": {
             "Content-Type": "text/plain;charset=utf-8"
           },
           "method": "GET",
-          "timestamp": "2018-06-01T20:36:46.180Z",
+          "timestamp": "2018-06-22T18:07:44.263Z",
           "url": "/api/db/-pollyjs_2160168770%2Fcore_3713949822%2FIntegration-Adapters_529408267%2FXHR-Adapter-Rest-Persister_3659812972%2Fshould-respect-request-order_2914185093"
         },
         "response": {
@@ -114,11 +114,11 @@
           "headers": {
             "connection": "close",
             "content-length": "0",
-            "date": "Fri, 01 Jun 2018 20",
+            "date": "Fri, 22 Jun 2018 18",
             "x-powered-by": "Express"
           },
           "status": 404,
-          "timestamp": "2018-06-01T20:36:46.191Z"
+          "timestamp": "2018-06-22T18:07:44.273Z"
         }
       }
     ]


### PR DESCRIPTION
Description of the symptoms of bug and the fix:

1. I run and recorded requests when I my tests in `http://localhost:3000`
2. I then pushed the branch to CI and it failed. It turns out that the recorded requests were not being replayed when ember-cli runs in CI.
3. After some debugging I discovered that the id of the request (the md5 generated from headers, url and method) is different because the normalized URL is different (`/my-url` was being normalized to `http://localhost:7357/my-url`)

The fix is to, on the URL normalization step, if the source url doesn't have a domain, the normalized version should not contain a domain either, effectively keeping the URL relative.

**Warning**: This is a breaking change. Recordings of relative urls that have already been captured will have to be re-recorded.