### PR TITLE
CORs passthrough on node-server

### DIFF
--- a/packages/@pollyjs/node-server/package.json
+++ b/packages/@pollyjs/node-server/package.json
@@ -46,6 +46,7 @@
   },
   "dependencies": {
     "body-parser": "^1.18.3",
+    "cors": "^2.8.4",
     "express": "^4.16.3",
     "fs-extra": "^5.0.0",
     "http-graceful-shutdown": "^2.1.1",

--- a/packages/@pollyjs/node-server/src/server.js
+++ b/packages/@pollyjs/node-server/src/server.js
@@ -36,7 +36,9 @@ export default class Server {
     this.server = this.app
       .listen(port, host)
       .on('listening', () => {
-        console.log(`Listening on http://${host || 'localhost'}:${port}/\n`);
+        if (!this.config.quiet) {
+          console.log(`Listening on http://${host || 'localhost'}:${port}/\n`);
+        }
       })
       .on('error', e => {
         if (e.code === 'EADDRINUSE') {

--- a/packages/@pollyjs/node-server/src/server.js
+++ b/packages/@pollyjs/node-server/src/server.js
@@ -1,5 +1,6 @@
 /* global process */
 
+import cors from 'cors';
 import morgan from 'morgan';
 import express from 'express';
 import gracefulShutdown from 'http-graceful-shutdown';
@@ -10,6 +11,7 @@ export default class Server {
   constructor(config = {}) {
     this.config = { ...DefaultConfig, ...config };
     this.app = express();
+    this.app.use(cors());
 
     if (!this.config.quiet) {
       this.app.use(morgan('dev'));

--- a/packages/@pollyjs/node-server/yarn.lock
+++ b/packages/@pollyjs/node-server/yarn.lock
@@ -254,6 +254,13 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
+cors@^2.8.4:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.4.tgz#2bd381f2eb201020105cd50ea59da63090694686"
+  dependencies:
+    object-assign "^4"
+    vary "^1"
+
 cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -948,7 +955,7 @@ npm-run-all@^4.1.2:
     shell-quote "^1.6.1"
     string.prototype.padend "^3.0.0"
 
-object-assign@^4.0.1:
+object-assign@^4, object-assign@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -1419,7 +1426,7 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-vary@~1.1.2:
+vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
 


### PR DESCRIPTION
Related to comments in #19 

Address the nuance of having to pass in the testURL as the hostname of the node server.  Now testURL can be anything (other than the default `about:blank`), we recommend `http://localhost` to be the default.