### PR TITLE
Brings back Polly.configure, Presets persisterOptions.host to the node server default, Preconfigure ember addon

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -49,7 +49,7 @@ module.exports = {
     {
       files: ['**/*/tests/**/*-test.js'],
       env: {
-        mocha: true,
+        mocha: true
       },
       globals: {
         chai: true,

--- a/docs/node-server/overview.md
+++ b/docs/node-server/overview.md
@@ -32,7 +32,7 @@ const { Server } = require('@pollyjs/node-server');
 const server = new Server({
   quiet: true,
   port: 4000,
-  apiNamespace: 'pollyjs'
+  apiNamespace: '/pollyjs'
 });
 
 // Add custom business logic to the express server

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-node": "^5.2.1",
     "eslint-plugin-prettier": "^2.6.0",
-    "formdata-polyfill": "^3.0.10",
     "husky": "^0.14.3",
     "lerna": "^2.11.0",
     "lerna-alias": "^3.0.2",

--- a/packages/@pollyjs/core/package.json
+++ b/packages/@pollyjs/core/package.json
@@ -63,6 +63,7 @@
   },
   "devDependencies": {
     "eslint": "^4.18.1",
+    "formdata-polyfill": "^3.0.11",
     "npm-run-all": "^4.1.2",
     "prettier": "^1.10.2",
     "rimraf": "^2.6.2",

--- a/packages/@pollyjs/core/src/defaults/config.js
+++ b/packages/@pollyjs/core/src/defaults/config.js
@@ -16,7 +16,7 @@ export default {
 
   persister: 'rest',
   persisterOptions: {
-    host: '',
+    host: 'http://localhost:3000',
     apiNamespace: '/polly'
   },
 

--- a/packages/@pollyjs/core/src/polly.js
+++ b/packages/@pollyjs/core/src/polly.js
@@ -13,6 +13,7 @@ import { version } from '../package.json';
 import { MODES, assert } from '@pollyjs/utils';
 
 const RECORDING_NAME = Symbol();
+const CLASS_CONFIG = Symbol();
 const RECORDING_ID = Symbol();
 const PAUSED_MODE = Symbol();
 const { isArray } = Array;
@@ -115,7 +116,12 @@ export default class Polly {
 
     const { _container: container } = this;
 
-    this.config = mergeOptions(DefaultConfig, this.config, config);
+    this.config = mergeOptions(
+      DefaultConfig,
+      Polly[CLASS_CONFIG],
+      this.config,
+      config
+    );
 
     // Handle Adapters
     this.config.adapters.forEach(adapter => {
@@ -151,6 +157,20 @@ export default class Polly {
     }
 
     this.persister = new (container.get(`persister:${persisterName}`))(this);
+  }
+
+  /**
+   * Do not use `configure` this will be removed in the future in favor of
+   * eventing `Polly.on('create', (instance) => {})`
+   * @private
+   */
+  static configure(config) {
+    Polly[CLASS_CONFIG] = mergeOptions({}, Polly[CLASS_CONFIG], config);
+  }
+
+  /** @private **/
+  static clearConfig() {
+    Polly[CLASS_CONFIG] = undefined;
   }
 
   /**

--- a/packages/@pollyjs/core/tests/integration/configs.js
+++ b/packages/@pollyjs/core/tests/integration/configs.js
@@ -1,20 +1,27 @@
+const common = {
+  recordFailedRequests: true,
+  persisterOptions: {
+    host: ''
+  }
+};
+
 export default {
   'XHR Adapter + Rest Persister': {
     adapters: ['xhr'],
-    recordFailedRequests: true
+    ...common
   },
   'Fetch Adapter + Rest Persister': {
     adapters: ['fetch'],
-    recordFailedRequests: true
+    ...common
   },
   'Fetch Adapter + Local Storage Persister': {
     adapters: ['fetch'],
     persister: 'local-storage',
-    recordFailedRequests: true
+    ...common
   },
   'XHR Adapter + Local Storage Persister': {
     adapters: ['xhr'],
     persister: 'local-storage',
-    recordFailedRequests: true
+    ...common
   }
 };

--- a/packages/@pollyjs/core/tests/unit/polly-test.js
+++ b/packages/@pollyjs/core/tests/unit/polly-test.js
@@ -178,6 +178,28 @@ describe('Unit | Polly', function() {
       expect(this.polly.config.adapters.length).to.equal(1);
     });
 
+    it('should merge static configure() with instance configure()', async function() {
+      expect(Polly.configure).to.be.a('function');
+      expect(Polly.clearConfig).to.be.a('function');
+
+      Polly.configure({ foo: 'foo', bar: 'bar' });
+      const polly = new Polly('foo', { adapters: [], foo: 'bar' });
+
+      polly.configure({ bar: 'baz' });
+      expect(polly.config.foo).to.equal('bar');
+      expect(polly.config.bar).to.equal('baz');
+
+      polly.configure({ foo: 'instance configure() can override' });
+      expect(polly.config.foo).to.equal('instance configure() can override');
+
+      /* should not mutate this.polly.config */
+      Polly.configure({ foo: 'static configure() cannot' });
+      expect(polly.config.foo).to.equal('instance configure() can override');
+      Polly.clearConfig();
+
+      await polly.stop();
+    });
+
     it('should connect to new adapters', async function() {
       expect(nativeFetch).to.equal(self.fetch);
       this.polly.configure({ adapters: ['fetch'] });

--- a/packages/@pollyjs/core/yarn.lock
+++ b/packages/@pollyjs/core/yarn.lock
@@ -419,6 +419,10 @@ foreach@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
 
+formdata-polyfill@^3.0.11:
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-3.0.11.tgz#c82b4b4bea3356c0a6752219e54ce1edb2a7fb5b"
+
 from@~0:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"

--- a/packages/@pollyjs/ember/addon/-private/preconfigure.js
+++ b/packages/@pollyjs/ember/addon/-private/preconfigure.js
@@ -1,0 +1,15 @@
+import { Polly } from '@pollyjs/core';
+
+Polly.configure({
+  /**
+   * @pollyjs/ember mounts the express middleware onto to the running
+   * testem and ember-cli express server and a relative host (an empty `host`)
+   * is preferred here.  Can be overridden at runtime in cases where the
+   * Polly server is externally hosted.
+   */
+  persisterOptions: {
+    host: ''
+  }
+});
+
+export default Polly;

--- a/packages/@pollyjs/ember/index.js
+++ b/packages/@pollyjs/ember/index.js
@@ -75,6 +75,21 @@ module.exports = {
       : null;
   },
 
+  treeForAddon() {
+    if (!this._config.enabled) {
+      return;
+    }
+
+    const tree = this._super.treeForAddon.apply(this, arguments);
+
+    return mergeTrees([
+      tree,
+      funnel(`${__dirname}/vendor/`, {
+        files: ['~preconfigure-polly.js']
+      })
+    ]);
+  },
+
   treeForVendor() {
     if (!this._config.enabled) {
       return;

--- a/packages/@pollyjs/ember/tests/unit/polly-test.js
+++ b/packages/@pollyjs/ember/tests/unit/polly-test.js
@@ -6,6 +6,13 @@ module('Unit | Polly | General', function() {
     test('it works', function(assert) {
       assert.equal(typeof Polly, 'function');
     });
+
+    test('it defaults to an empty string for persisterOptions.host', function(assert) {
+      const polly = new Polly('abc');
+      assert.equal(polly.config.persisterOptions.host, '');
+
+      return polly.stop();
+    });
   });
 
   module('setupPolly', function(hooks) {

--- a/packages/@pollyjs/ember/vendor/~preconfigure-polly.js
+++ b/packages/@pollyjs/ember/vendor/~preconfigure-polly.js
@@ -1,0 +1,5 @@
+(function() {
+  /* globals require */
+  'use strict';
+  require('@pollyjs/ember/-private/preconfigure');
+})();

--- a/packages/@pollyjs/node-server/README.md
+++ b/packages/@pollyjs/node-server/README.md
@@ -44,7 +44,7 @@ const { Server } = require('@pollyjs/node-server');
 const server = new Server({
   quiet: true,
   port: 4000,
-  apiNamespace: 'pollyjs'
+  apiNamespace: '/pollyjs'
 });
 
 // Add custom business logic to the express server

--- a/yarn.lock
+++ b/yarn.lock
@@ -2464,10 +2464,6 @@ form-data@~2.3.1:
     combined-stream "1.0.6"
     mime-types "^2.1.12"
 
-formdata-polyfill@^3.0.10:
-  version "3.0.10"
-  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-3.0.10.tgz#4e1bfcc1e131f73b07856fc159ee103d0b37ec3c"
-
 forwarded@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"


### PR DESCRIPTION
- Brings back Polly.configure
- Preconfigure `persisterOptions.host` to `http://localhost:3000` which is the node server default #19 
- Preconfigure ember addon with relative host (empty `host`)