### PR TITLE
feat: Improved adapter and persister registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,18 @@ Check out the [Quick Start](https://netflix.github.io/pollyjs/#/quick-start) doc
 
 ## Usage
 
-Let's take a look at what an example test case would look like using Polly.
+Lets take a look at what an example test case would look like using Polly.
 
 ```js
-import { Polly } from '@pollyjs/core';
+import { Polly, FetchAdapter, XHRAdapter, RESTPersister } from '@pollyjs/core';
+
+/*
+  Register the adapters and persisters we want to use. This way all future
+  polly instances can access them by name.
+*/
+Polly.register(XHRAdapter)
+Polly.register(FetchAdapter)
+Polly.register(RESTPersister)
 
 describe('Netflix Homepage', function() {
   it('should be able to sign in', async function() {
@@ -52,7 +60,10 @@ describe('Netflix Homepage', function() {
       will record any requests that it hasn't yet seen while replaying ones it
       has already recorded.
     */
-    const polly = new Polly('Sign In');
+    const polly = new Polly('Sign In', {
+      adapters: ['xhr', 'fetch'],
+      persister: 'rest'
+    });
     const { server } = polly;
 
     /* Intercept all Google Analytic requests and respond with a 200 */

--- a/docs/adapters/custom.md
+++ b/docs/adapters/custom.md
@@ -67,33 +67,13 @@ adapter class.
 ```js
 // Register and connect to a custom adapter:
 new Polly('Custom Adapter', {
-  adapters: [
-    ['my-custom-adapter', MyCustomAdapterClass]
-  ]
-});
-
-// Register and connect to the default adapters + a custom adapter:
-new Polly('Defaults + Custom Adapter', {
-  adapters: [
-    'fetch',
-    'xhr',
-    ['my-custom-adapter', MyCustomAdapterClass]
-  ]
-});
-
-// Register and connect to a custom fetch adapter:
-new Polly('Custom Fetch Adapter', {
-  adapters: [
-    ['fetch', MyCustomFetchAdapterClass]
-  ]
+  adapters: [MyCustomAdapterClass]
 });
 
 // Register and connect to a custom adapter via .configure():
 const polly = new Polly('Custom Adapter');
 
 polly.configure({
-  adapters: [
-    ['my-custom-adapter', MyCustomAdapterClass]
-  ]
+  adapters: [MyCustomAdapterClass]
 });
 ```

--- a/docs/adapters/fetch.md
+++ b/docs/adapters/fetch.md
@@ -11,6 +11,11 @@ The fetch adapter is connected to by default but you can use the
 adapter.
 
 ```js
+import { Polly, FetchAdapter } from '@pollyjs/core';
+
+// Register the fetch adapter so its accessible by all future polly instances
+Polly.register(FetchAdapter);
+
 const polly = new Polly('<Recording Name>', {
   adapters: ['fetch']
 });

--- a/docs/adapters/xhr.md
+++ b/docs/adapters/xhr.md
@@ -12,6 +12,11 @@ The XHR adapter is connected to by default but you can use the
 adapter.
 
 ```js
+import { Polly, XHRAdapter } from '@pollyjs/core';
+
+// Register the xhr adapter so its accessible by all future polly instances
+Polly.register(XHRAdapter);
+
 const polly = new Polly('<Recording Name>', {
   adapters: ['xhr']
 });

--- a/docs/api.md
+++ b/docs/api.md
@@ -218,12 +218,13 @@ Connect to an adapter.
 
 | Param | Type | Description |
 |  ---  | ---  |     ---     |
-| name | `String` | The name of the adapter to connect to |
+| name | `String|Function` | The adapter name of class to connect to |
 
 __Example__
 
 ```js
 polly.connectTo('xhr');
+polly.connectTo(XHRAdapter);
 ```
 
 ### disconnectFrom
@@ -232,12 +233,13 @@ Disconnect from an adapter.
 
 | Param | Type | Description |
 |  ---  | ---  |     ---     |
-| name | `String` | The name of the adapter to disconnect from |
+| name | `String|Function` | The adapter name of class to disconnect from |
 
 __Example__
 
 ```js
 polly.disconnectFrom('xhr');
+polly.disconnectFrom(XHRAdapter);
 ```
 
 ### disconnect

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -128,16 +128,18 @@ polly.configure({
 
 ## adapters
 
-_Type_: `Array`
-_Default_: `['fetch', 'xhr']`
+_Type_: `Array[String|Function]`
+_Default_: `[]`
 
 The adapter(s) polly will hook into.
 
 __Example__
 
 ```js
+import { FetchAdapter } from '@pollyjs/core';
+
 polly.configure({
-  adapters: ['xhr']
+  adapters: ['xhr', FetchAdapter]
 });
 ```
 
@@ -165,16 +167,25 @@ polly.configure({
 
 ## persister
 
-_Type_: `String`
-_Default_: `'rest'`
+_Type_: `String|Function`
+_Default_: `null`
 
 The persister to use for recording and replaying requests.
 
 __Example__
 
 ```js
+import { LocalStoragePersister, RESTPersister } from '@pollyjs/core';
+
+// Register the local-storage persister so its accessible by all future polly instances
+Polly.register(LocalStoragePersister);
+
 polly.configure({
   persister: 'local-storage'
+});
+
+polly.configure({
+  persister: RESTPersister
 });
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -136,7 +136,10 @@ The adapter(s) polly will hook into.
 __Example__
 
 ```js
-import { FetchAdapter } from '@pollyjs/core';
+import { XHRAdapter, FetchAdapter } from '@pollyjs/core';
+
+// Register the xhr adapter so its accessible by all future polly instances
+Polly.register(XHRAdapter);
 
 polly.configure({
   adapters: ['xhr', FetchAdapter]

--- a/docs/persisters/custom.md
+++ b/docs/persisters/custom.md
@@ -29,6 +29,10 @@ yarn add @pollyjs/persister -D
 import Persister from '@pollyjs/persister';
 
 class CustomPersister extends Persister {
+  static get name() {
+    return 'custom';
+  }
+
   findRecording() {}
 
   saveRecording() {}
@@ -61,13 +65,13 @@ persister class.
 ```js
 // Register and connect to a custom persister:
 new Polly('Custom Persister', {
-  persister: ['my-custom-persister', MyCustomPersisterClass]
+  persister: MyCustomPersisterClass
 });
 
 // Register and connect to a custom persister via .configure():
 const polly = new Polly('Custom Persister');
 
 polly.configure({
-  persister: ['my-custom-persister', MyCustomPersisterClass]
+  persister: MyCustomPersisterClass
 });
 ```

--- a/docs/persisters/fs.md
+++ b/docs/persisters/fs.md
@@ -22,8 +22,11 @@ yarn add @pollyjs/persister-fs -D
 import { Polly } from '@pollyjs/core';
 import FSPersister from '@pollyjs/persister-fs';
 
+// Register the fs persister so its accessible by all future polly instances
+Polly.register(FSPersister);
+
 new Polly('<Recording Name>', {
-  persister: ['fs', FSPersister]
+  persister: 'fs'
 });
 ```
 

--- a/docs/persisters/local-storage.md
+++ b/docs/persisters/local-storage.md
@@ -5,7 +5,12 @@ Read and write recordings to and from the browser's Local Storage.
 ## Usage
 
 ```js
-const polly = new Polly('<Recording Name>', {
+import { Polly, LocalStoragePersister } from '@pollyjs/core';
+
+// Register the local-storage persister so its accessible by all future polly instances
+Polly.register(LocalStoragePersister);
+
+new Polly('<Recording Name>', {
   persister: 'local-storage'
 });
 ```

--- a/docs/persisters/rest.md
+++ b/docs/persisters/rest.md
@@ -11,14 +11,13 @@ as well as a [CLI](cli/overview) to get you up and running.
 ## Usage
 
 ```js
+import { Polly, RESTPersister } from '@pollyjs/core';
+
+// Register the REST persister so its accessible by all future polly instances
+Polly.register(RESTPersister);
+
 new Polly('<Recording Name>', {
-  persister: 'rest',
-  persisterOptions: {
-    rest: {
-      host: '',
-      apiNamespace: '/polly'
-    }
-  }
+  persister: 'rest'
 });
 ```
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -50,7 +50,15 @@ Now that you've installed Polly and have setup your server, you're ready to
 fly. Lets take a look at what an example test case would look like using Polly.
 
 ```js
-import { Polly } from '@pollyjs/core';
+import { Polly, FetchAdapter, XHRAdapter, RESTPersister } from '@pollyjs/core';
+
+/*
+  Register the adapters and persisters we want to use. This way all future
+  polly instances can access them by name.
+*/
+Polly.register(XHRAdapter)
+Polly.register(FetchAdapter)
+Polly.register(RESTPersister)
 
 describe('Netflix Homepage', function() {
   it('should be able to sign in', async function() {
@@ -61,7 +69,19 @@ describe('Netflix Homepage', function() {
       will record any requests that it hasn't yet seen while replaying ones it
       has already recorded.
     */
-    const polly = new Polly('Sign In');
+    const polly = new Polly('Sign In', {
+      adapters: ['xhr', 'fetch'],
+      persister: 'rest'
+    });
+    const { server } = polly;
+
+    /* Intercept all Google Analytic requests and respond with a 200 */
+    server
+      .get('/google-analytics/*path')
+      .intercept((req, res) => res.sendStatus(200));
+
+    /* Pass-through all GET requests to /coverage */
+    server.get('/coverage').passthrough();
 
     /* start: pseudo test code */
     await visit('/login');
@@ -169,7 +189,10 @@ import { Polly } from '@pollyjs/core';
 
 describe('Netflix Homepage', function() {
   it('should handle a failed sign in attempt', async function() {
-    const polly = new Polly('Failed Sign In');
+    const polly = new Polly('Failed Sign In', {
+      adapters: ['xhr', 'fetch'],
+      persister: 'rest'
+    });
     const { server } = polly;
 
     /*

--- a/packages/@pollyjs/core/README.md
+++ b/packages/@pollyjs/core/README.md
@@ -54,7 +54,15 @@ Check out the [Quick Start](https://netflix.github.io/pollyjs/#/quick-start) doc
 Lets take a look at what an example test case would look like using Polly.
 
 ```js
-import { Polly } from '@pollyjs/core';
+import { Polly, FetchAdapter, XHRAdapter, RESTPersister } from '@pollyjs/core';
+
+/*
+  Register the adapters and persisters we want to use. This way all future
+  polly instances can access them by name.
+*/
+Polly.register(XHRAdapter)
+Polly.register(FetchAdapter)
+Polly.register(RESTPersister)
 
 describe('Netflix Homepage', function() {
   it('should be able to sign in', async function() {
@@ -65,7 +73,10 @@ describe('Netflix Homepage', function() {
       will record any requests that it hasn't yet seen while replaying ones it
       has already recorded.
     */
-    const polly = new Polly('Sign In');
+    const polly = new Polly('Sign In', {
+      adapters: ['xhr', 'fetch'],
+      persister: 'rest'
+    });
     const { server } = polly;
 
     /* Intercept all Google Analytic requests and respond with a 200 */

--- a/packages/@pollyjs/core/src/-private/container.js
+++ b/packages/@pollyjs/core/src/-private/container.js
@@ -1,5 +1,9 @@
 import { assert } from '@pollyjs/utils';
 
+function keyFor(Factory) {
+  return `${Factory.type}:${Factory.name}`;
+}
+
 export default class Container {
   constructor() {
     this._registry = new Map();
@@ -28,31 +32,21 @@ export default class Container {
       typeof type === 'string'
     );
 
-    this._registry.set(`${type}:${name}`, Factory);
+    this._registry.set(keyFor(Factory), Factory);
   }
 
   /**
    * Unregister a factory from the container via a key (e.g. `adapter:fetch`)
-   * or the Factory class.
+   * or Factory class.
    *
    * @param {String|Function} keyOrFactory
    */
   unregister(keyOrFactory) {
     const { _registry: registry } = this;
+    const key =
+      typeof keyOrFactory === 'function' ? keyFor(keyOrFactory) : keyOrFactory;
 
-    // Unregister by key
-    if (typeof keyOrFactory === 'string') {
-      registry.delete(keyOrFactory);
-    }
-
-    // Unregister by Factory
-    if (typeof keyOrFactory === 'function') {
-      for (const [key, Factory] of registry.entries()) {
-        if (Factory === keyOrFactory) {
-          registry.delete(key);
-        }
-      }
-    }
+    registry.delete(key);
   }
 
   /**
@@ -66,13 +60,17 @@ export default class Container {
   }
 
   /**
-   * Check if a factory has been registered by the
-   * given key (e.g. `adapter:fetch`)
+   * Check if a factory has been registered via a key (e.g. `adapter:fetch`)
+   * or Factory class.
    *
-   * @param {String} key
+   * @param {String|Function} keyOrFactory
    * @returns {Boolean}
    */
-  has(key) {
-    return this._registry.has(key);
+  has(keyOrFactory) {
+    const { _registry: registry } = this;
+    const key =
+      typeof keyOrFactory === 'function' ? keyFor(keyOrFactory) : keyOrFactory;
+
+    return registry.has(key);
   }
 }

--- a/packages/@pollyjs/core/src/-private/container.js
+++ b/packages/@pollyjs/core/src/-private/container.js
@@ -1,17 +1,78 @@
 import { assert } from '@pollyjs/utils';
 
-export default class Container extends Map {
-  set(name, Type) {
+export default class Container {
+  constructor() {
+    this._registry = new Map();
+  }
+
+  /**
+   * Register a factory onto the container.
+   *
+   * @param {Function} Factory
+   */
+  register(Factory) {
+    assert(
+      `Attempted to register ${Factory} but invalid factory provided. Expected function, received: "${typeof Factory}"`,
+      typeof Factory === 'function'
+    );
+
+    const { type, name } = Factory;
+
     assert(
       `Invalid registration name provided. Expected string, received: "${typeof name}"`,
       typeof name === 'string'
     );
 
     assert(
-      `Attempted to register ${name} but invalid factory type provided. Expected function, received: "${typeof Type}"`,
-      typeof Type === 'function'
+      `Invalid registration type provided. Expected string, received: "${typeof type}"`,
+      typeof type === 'string'
     );
 
-    return super.set(name, Type);
+    this._registry.set(`${type}:${name}`, Factory);
+  }
+
+  /**
+   * Unregister a factory from the container via a key (e.g. `adapter:fetch`)
+   * or the Factory class.
+   *
+   * @param {String|Function} keyOrFactory
+   */
+  unregister(keyOrFactory) {
+    const { _registry: registry } = this;
+
+    // Unregister by key
+    if (typeof keyOrFactory === 'string') {
+      registry.delete(keyOrFactory);
+    }
+
+    // Unregister by Factory
+    if (typeof keyOrFactory === 'function') {
+      for (const [key, Factory] of registry.entries()) {
+        if (Factory === keyOrFactory) {
+          registry.delete(key);
+        }
+      }
+    }
+  }
+
+  /**
+   * Lookup a factory by the given key (e.g. `adapter:fetch`)
+   *
+   * @param {String} key
+   * @returns {Function}
+   */
+  lookup(key) {
+    return this._registry.get(key) || null;
+  }
+
+  /**
+   * Check if a factory has been registered by the
+   * given key (e.g. `adapter:fetch`)
+   *
+   * @param {String} key
+   * @returns {Boolean}
+   */
+  has(key) {
+    return this._registry.has(key);
   }
 }

--- a/packages/@pollyjs/core/src/defaults/config.js
+++ b/packages/@pollyjs/core/src/defaults/config.js
@@ -4,7 +4,7 @@ import Timing from '../utils/timing';
 export default {
   mode: MODES.REPLAY,
 
-  adapters: ['fetch', 'xhr'],
+  adapters: [],
   adapterOptions: {},
 
   logging: false,
@@ -16,7 +16,7 @@ export default {
   expiresIn: null,
   timing: Timing.fixed(0),
 
-  persister: 'rest',
+  persister: null,
   persisterOptions: {},
 
   matchRequestsBy: {

--- a/packages/@pollyjs/core/src/polly.js
+++ b/packages/@pollyjs/core/src/polly.js
@@ -239,16 +239,17 @@ export default class Polly {
   }
 
   /**
-   * @param {String} adapterName
+   * @param {String|Function} nameOrFactory
    * @public
    * @memberof Polly
    */
-  connectTo(adapterName) {
+  connectTo(nameOrFactory) {
     const { container, adapters } = this;
+    let adapterName = nameOrFactory;
 
-    if (typeof adapterName === 'function') {
-      container.register(adapterName);
-      adapterName = adapterName.name;
+    if (typeof nameOrFactory === 'function') {
+      container.register(nameOrFactory);
+      adapterName = nameOrFactory.name;
     }
 
     assert(
@@ -265,12 +266,17 @@ export default class Polly {
   }
 
   /**
-   * @param {String} adapterName
+   * @param {String|Function} nameOrFactory
    * @public
    * @memberof Polly
    */
-  disconnectFrom(adapterName) {
+  disconnectFrom(nameOrFactory) {
     const { adapters } = this;
+    let adapterName = nameOrFactory;
+
+    if (typeof nameOrFactory === 'function') {
+      adapterName = nameOrFactory.name;
+    }
 
     if (adapters.has(adapterName)) {
       adapters.get(adapterName).disconnect();

--- a/packages/@pollyjs/core/tests/browser/helpers/setup-fetch.js
+++ b/packages/@pollyjs/core/tests/browser/helpers/setup-fetch.js
@@ -6,17 +6,15 @@ export default function setupFetch(fetchType) {
   afterEachWrapper();
 }
 
-function beforeEachWrapper(fetchType) {
+function beforeEachWrapper() {
   beforeEach(function() {
-    this.fetch = (...args) => {
-      if (fetchType === 'xhr') {
-        return xhrRequest(...args);
-      } else if (fetchType === 'fetch') {
-        return fetch(...args);
-      } else {
-        throw new TypeError(`Unknown fetch type: ${fetchType}.`);
-      }
-    };
+    if (this.polly.adapters.has('xhr')) {
+      this.fetch = (...args) => xhrRequest(...args);
+    } else if (this.polly.adapters.has('fetch')) {
+      this.fetch = (...args) => fetch(...args);
+    } else {
+      throw new TypeError(`[setupFetch] No usable network adapter.`);
+    }
 
     this.recordUrl = () =>
       `/api/db/${encodeURIComponent(this.polly.recordingId)}`;
@@ -26,9 +24,9 @@ function beforeEachWrapper(fetchType) {
 
 export function afterEachWrapper() {
   afterEach(async function() {
-    this.polly.stop();
-
+    this.polly.pause();
     await this.fetchRecord({ method: 'DELETE' });
+    this.polly.play();
   });
 }
 export { beforeEachWrapper as beforeEach };

--- a/packages/@pollyjs/core/tests/browser/integration/adapters-test.js
+++ b/packages/@pollyjs/core/tests/browser/integration/adapters-test.js
@@ -12,7 +12,7 @@ describe('Integration | Adapters', function() {
 
     describe(name, function() {
       setupPolly.beforeEach(defaults);
-      setupFetch.beforeEach(defaults.adapters[0]);
+      setupFetch.beforeEach();
       setupFetch.afterEach();
       setupPolly.afterEach();
 

--- a/packages/@pollyjs/core/tests/browser/integration/configs.js
+++ b/packages/@pollyjs/core/tests/browser/integration/configs.js
@@ -1,3 +1,10 @@
+import {
+  XHRAdapter,
+  FetchAdapter,
+  RESTPersister,
+  LocalStoragePersister
+} from '../../../src';
+
 const common = {
   recordFailedRequests: true,
   persisterOptions: {
@@ -7,21 +14,23 @@ const common = {
 
 export default {
   'XHR Adapter + Rest Persister': {
-    adapters: ['xhr'],
+    adapters: [XHRAdapter],
+    persister: RESTPersister,
     ...common
   },
   'Fetch Adapter + Rest Persister': {
-    adapters: ['fetch'],
+    adapters: [FetchAdapter],
+    persister: RESTPersister,
     ...common
   },
   'Fetch Adapter + Local Storage Persister': {
-    adapters: ['fetch'],
-    persister: 'local-storage',
+    adapters: [FetchAdapter],
+    persister: LocalStoragePersister,
     ...common
   },
   'XHR Adapter + Local Storage Persister': {
-    adapters: ['xhr'],
-    persister: 'local-storage',
+    adapters: [XHRAdapter],
+    persister: LocalStoragePersister,
     ...common
   }
 };

--- a/packages/@pollyjs/core/tests/browser/integration/server-test.js
+++ b/packages/@pollyjs/core/tests/browser/integration/server-test.js
@@ -1,7 +1,14 @@
-import { setupMocha as setupPolly } from '../../../src';
+import {
+  setupMocha as setupPolly,
+  FetchAdapter,
+  RESTPersister
+} from '../../../src';
 
 describe('Integration | Server', function() {
-  setupPolly();
+  setupPolly({
+    adapters: [FetchAdapter],
+    persister: RESTPersister
+  });
 
   describe('Events & Middleware', function() {
     it('event: request', async function() {

--- a/packages/@pollyjs/core/tests/unit/-private/container-test.js
+++ b/packages/@pollyjs/core/tests/unit/-private/container-test.js
@@ -1,0 +1,82 @@
+import Container from '../../../src/-private/container';
+
+let container;
+
+class Factory {
+  static get name() {
+    return 'foo';
+  }
+
+  static get type() {
+    return 'factory';
+  }
+}
+
+describe('Unit | Container', function() {
+  it('should exist', function() {
+    expect(() => new Container()).to.not.throw();
+    expect(new Container()).to.exist;
+  });
+
+  describe('API', function() {
+    beforeEach(function() {
+      container = new Container();
+    });
+
+    it('.register()', function() {
+      container.register(Factory);
+      expect(container.has('factory:foo')).to.be.true;
+    });
+
+    it('.register() - validation', function() {
+      class NoName extends Factory {
+        static get name() {}
+      }
+
+      class NoType extends Factory {
+        static get type() {}
+      }
+
+      expect(() => container.register()).to.throw(
+        Error,
+        /invalid factory provided/
+      );
+      expect(() => container.register(NoName)).to.throw(
+        Error,
+        /Invalid registration name provided/
+      );
+      expect(() => container.register(NoType)).to.throw(
+        Error,
+        /Invalid registration type provided/
+      );
+    });
+
+    it('.unregister() - by key', function() {
+      container.register(Factory);
+      expect(container.has('factory:foo')).to.be.true;
+
+      container.unregister('factory:foo');
+      expect(container.has('factory:foo')).to.be.false;
+    });
+
+    it('.unregister() - by factory', function() {
+      container.register(Factory);
+      expect(container.has('factory:foo')).to.be.true;
+
+      container.unregister(Factory);
+      expect(container.has('factory:foo')).to.be.false;
+    });
+
+    it('.lookup()', function() {
+      container.register(Factory);
+      expect(container.lookup('factory:foo')).to.equal(Factory);
+      expect(container.lookup('factory:bar')).to.be.null;
+    });
+
+    it('.has()', function() {
+      container.register(Factory);
+      expect(container.has('factory:foo')).to.be.true;
+      expect(container.has('factory:bar')).to.be.false;
+    });
+  });
+});

--- a/packages/@pollyjs/core/tests/unit/-private/container-test.js
+++ b/packages/@pollyjs/core/tests/unit/-private/container-test.js
@@ -73,10 +73,16 @@ describe('Unit | Container', function() {
       expect(container.lookup('factory:bar')).to.be.null;
     });
 
-    it('.has()', function() {
+    it('.has() - by key', function() {
       container.register(Factory);
       expect(container.has('factory:foo')).to.be.true;
       expect(container.has('factory:bar')).to.be.false;
+    });
+
+    it('.has() - by factory', function() {
+      container.register(Factory);
+      expect(container.has(Factory)).to.be.true;
+      expect(container.has(class Foo extends Factory {})).to.be.false;
     });
   });
 });

--- a/packages/@pollyjs/core/tests/unit/test-helpers/mocha-test.js
+++ b/packages/@pollyjs/core/tests/unit/test-helpers/mocha-test.js
@@ -28,7 +28,7 @@ describe('Unit | Test Helpers | mocha', function() {
   it('should invoke beforeEach and afterEach', function() {
     const stub = new Sandbox();
 
-    setupPolly({ adapters: [] }, stub);
+    setupPolly({}, stub);
     expect(stub.beforeEachCalled.size).to.equal(1);
     expect(stub.afterEachCalled.size).to.equal(1);
   });
@@ -42,7 +42,7 @@ describe('Unit | Test Helpers | mocha', function() {
 
     const stub = new Sandbox(ctx);
 
-    setupPolly({ adapters: [] }, stub);
+    setupPolly({}, stub);
     expect(ctx.polly).to.be.a('object');
     expect(ctx.polly.recordingName).to.equal('foo');
   });
@@ -62,7 +62,7 @@ describe('Unit | Test Helpers | mocha', function() {
 
     const stub = new Sandbox(ctx);
 
-    setupPolly({ adapters: [] }, stub);
+    setupPolly({}, stub);
     expect(ctx.polly.recordingName).to.equal('baz/bar/foo');
   });
 });

--- a/packages/@pollyjs/ember/addon/-private/preconfigure.js
+++ b/packages/@pollyjs/ember/addon/-private/preconfigure.js
@@ -1,7 +1,20 @@
-import { Polly } from '@pollyjs/core';
+import {
+  Polly,
+  XHRAdapter,
+  FetchAdapter,
+  RESTPersister,
+  LocalStoragePersister
+} from '@pollyjs/core';
+
+Polly.register(XHRAdapter);
+Polly.register(FetchAdapter);
+Polly.register(RESTPersister);
+Polly.register(LocalStoragePersister);
 
 Polly.on('create', polly => {
   polly.configure({
+    adapters: ['xhr', 'fetch'],
+    persister: 'rest',
     /**
      * @pollyjs/ember mounts the express middleware onto to the running
      * testem and ember-cli express server and a relative host (an empty `host`)

--- a/testem.js
+++ b/testem.js
@@ -8,7 +8,7 @@ module.exports = {
   watch_files: [
     './build-scripts/**/*',
     './packages/@pollyjs/*/src/**/*',
-    './packages/@pollyjs/*/tests*/*/*'
+    './packages/@pollyjs/*/tests/*/*'
   ],
   serve_files: ['./packages/@pollyjs/*/build/browser/*.js'],
   browser_args: {


### PR DESCRIPTION
__Adapters__

```js
import { XHRAdapter, FetchAdapter } from '@pollyjs/core';

// Register the xhr adapter so its accessible by all future polly instances
Polly.register(XHRAdapter);

polly.configure({
  adapters: ['xhr', FetchAdapter]
});
```

__Persister__

```js
import { LocalStoragePersister, RESTPersister } from '@pollyjs/core';

// Register the local-storage persister so its accessible by all future polly instances
Polly.register(LocalStoragePersister);

polly.configure({
  persister: 'local-storage'
});

polly.configure({
  persister: RESTPersister
});
```