### PR TITLE
feat: Fetch adapter support for `context` provided via adapterOptions

### DIFF
--- a/docs/adapters/fetch.md
+++ b/docs/adapters/fetch.md
@@ -43,3 +43,25 @@ polly.connectTo('fetch');
 // Disconnect using the `disconnectFrom` API
 polly.disconnectFrom('fetch');
 ```
+
+## Options
+
+### context
+
+_Type_: 'Object'
+_Default_: `global|self|window`
+
+The context object which contains the fetch API.  Typically this is `window` or `self` in the browser and `global` in node.
+
+__Example__
+
+```js
+polly.configure({
+  adapters: ['fetch'],
+  adapterOptions: {
+    fetch: {
+      context: window
+    }
+  }
+});
+```

--- a/packages/@pollyjs/adapter-fetch/tests/integration/adapter-test.js
+++ b/packages/@pollyjs/adapter-fetch/tests/integration/adapter-test.js
@@ -1,4 +1,4 @@
-import { setupMocha as setupPolly } from '@pollyjs/core';
+import { setupMocha as setupPolly, Polly } from '@pollyjs/core';
 import setupFetchRecord from '@pollyjs-tests/helpers/setup-fetch-record';
 import adapterTests from '@pollyjs-tests/integration/adapter-tests';
 import adapterBrowserTests from '@pollyjs-tests/integration/adapter-browser-tests';
@@ -20,4 +20,103 @@ describe('Integration | Fetch Adapter', function() {
 
   adapterTests();
   adapterBrowserTests();
+});
+
+describe('Integration | Fetch Adapter | Context', function() {
+  it(`should assign context's fetch as the native fetch`, async function() {
+    const polly = new Polly('context', { adapters: [] });
+    const adapterOptions = {
+      fetch: {
+        context: {
+          fetch() {}
+        }
+      }
+    };
+
+    polly.configure({
+      adapters: [FetchAdapter],
+      adapterOptions
+    });
+
+    expect(polly.adapters.get('fetch').native).to.equal(
+      adapterOptions.fetch.context.fetch
+    );
+
+    expect(function() {
+      polly.configure({
+        adapterOptions: {
+          fetch: {
+            context: undefined
+          }
+        }
+      });
+    }).to.throw(`[Polly] [adapter:fetch] Fetch global not found.`);
+
+    await polly.stop();
+  });
+
+  it('should throw when context and fetch are undefined', async function() {
+    const polly = new Polly('context', { adapters: [] });
+
+    polly.configure({
+      adapters: [FetchAdapter]
+    });
+
+    expect(function() {
+      polly.configure({
+        adapterOptions: {
+          fetch: {
+            context: undefined
+          }
+        }
+      });
+    }).to.throw(`[Polly] [adapter:fetch] Fetch global not found.`);
+
+    expect(function() {
+      polly.configure({
+        adapterOptions: {
+          fetch: {
+            context: {
+              fetch: undefined
+            }
+          }
+        }
+      });
+    }).to.throw(`[Polly] [adapter:fetch] Fetch global not found.`);
+
+    await polly.stop();
+  });
+});
+
+describe('Integration | Fetch Adapter | Concurrency', function() {
+  it('should prevent concurrent fetch adapter instances', async function() {
+    const one = new Polly('one');
+    const two = new Polly('two');
+
+    one.connectTo(FetchAdapter);
+
+    expect(function() {
+      two.connectTo(FetchAdapter);
+    }).to.throw(
+      `[Polly] [adapter:fetch] Running concurrent fetch adapters is unsupported, stop any running Polly instances.`
+    );
+
+    await one.stop();
+    await two.stop();
+  });
+
+  it('should allow you to register new instances once stopped', async function() {
+    const one = new Polly('one');
+    const two = new Polly('two');
+
+    one.connectTo(FetchAdapter);
+    one.stop();
+
+    expect(function() {
+      two.connectTo(FetchAdapter);
+    }).to.not.throw();
+
+    await one.stop();
+    await two.stop();
+  });
 });

--- a/packages/@pollyjs/core/src/polly.js
+++ b/packages/@pollyjs/core/src/polly.js
@@ -121,12 +121,10 @@ export default class Polly {
       this.mode !== MODES.STOPPED
     );
 
-    this.config = mergeOptions(DefaultConfig, this.config, config);
-
-    /* Handle Adapters */
-
-    // Disconnect from all current adapters
+    // Disconnect from all current adapters before updating the config
     this.disconnect();
+
+    this.config = mergeOptions(DefaultConfig, this.config, config);
 
     // Register and connect to all specified adapters
     this.config.adapters.forEach(adapter => this.connectTo(adapter));


### PR DESCRIPTION
I'll update the docs also.

I can't  apply the same treatment to the XHR adapter since `nise` doesn't enable providing a context object.  I think we spoke about this already, but mentioning again.

Resolves #56