### PR TITLE
fix: Improve support for relative URLs

### DIFF
--- a/packages/@pollyjs/core/src/-private/request.js
+++ b/packages/@pollyjs/core/src/-private/request.js
@@ -3,7 +3,7 @@ import URL from 'url-parse';
 import stringify from 'fast-json-stable-stringify';
 import PollyResponse from './response';
 import NormalizeRequest from '../utils/normalize-request';
-import removeHostFromUrl from '../utils/remove-host-from-url';
+import parseUrl from '../utils/parse-url';
 import serializeRequestBody from '../utils/serialize-request-body';
 import isAbsoluteUrl from 'is-absolute-url';
 import { assert, timestamp } from '@pollyjs/utils';
@@ -48,18 +48,7 @@ export default class PollyRequest extends HTTPBase {
   }
 
   set url(value) {
-    const url = new URL(value, true);
-
-    /*
-      If the url is relative, setup the parsed url to reflect just that
-      by removing the host. By default URL sets the host via window.location if
-      it does not exist.
-    */
-    if (!isAbsoluteUrl(value)) {
-      removeHostFromUrl(url);
-    }
-
-    this[PARSED_URL] = url;
+    this[PARSED_URL] = parseUrl(value, true);
   }
 
   get absoluteUrl() {

--- a/packages/@pollyjs/core/src/utils/http-headers.js
+++ b/packages/@pollyjs/core/src/utils/http-headers.js
@@ -1,6 +1,7 @@
 import isObjectLike from 'lodash-es/isObjectLike';
 
 const { keys } = Object;
+
 const HANDLER = {
   get(obj, prop) {
     // `prop` can be a Symbol so only lower-case string based props.

--- a/packages/@pollyjs/core/src/utils/normalize-request.js
+++ b/packages/@pollyjs/core/src/utils/normalize-request.js
@@ -1,7 +1,5 @@
-import URL from 'url-parse';
-import removeHostFromUrl from './remove-host-from-url';
+import parseUrl from './parse-url';
 import isObjectLike from 'lodash-es/isObjectLike';
-import isAbsoluteUrl from 'is-absolute-url';
 import HTTPHeaders from './http-headers';
 import stringify from 'fast-json-stable-stringify';
 
@@ -14,12 +12,7 @@ export function method(method) {
 }
 
 export function url(url, config = {}) {
-  const parsedUrl = new URL(url, true);
-
-  // Remove the host if the url is relative
-  if (!isAbsoluteUrl(url)) {
-    removeHostFromUrl(parsedUrl);
-  }
+  const parsedUrl = parseUrl(url, true);
 
   // Remove any url properties that have been disabled via the config
   keys(config).forEach(key => !config[key] && parsedUrl.set(key, ''));

--- a/packages/@pollyjs/core/src/utils/parse-url.js
+++ b/packages/@pollyjs/core/src/utils/parse-url.js
@@ -1,0 +1,32 @@
+import URL from 'url-parse';
+import isAbsoluteUrl from 'is-absolute-url';
+import removeHostFromUrl from './remove-host-from-url';
+
+/**
+ * Creates an exact representation of the passed url string with url-parse.
+ *
+ * @param {String} url
+ * @param {...args} args Arguments to pass through to the URL constructor
+ * @returns {URL} A url-parse URL instance
+ */
+export default function parseUrl(url, ...args) {
+  const parsedUrl = new URL(url, ...args);
+
+  if (!isAbsoluteUrl(url)) {
+    if (url.startsWith('//')) {
+      /*
+        If the url is protocol-relative, strip out the protocol
+      */
+      parsedUrl.set('protocol', '');
+    } else {
+      /*
+        If the url is relative, setup the parsed url to reflect just that
+        by removing the host. By default URL sets the host via window.location if
+        it does not exist.
+      */
+      removeHostFromUrl(parsedUrl);
+    }
+  }
+
+  return parsedUrl;
+}

--- a/packages/@pollyjs/core/tests/unit/utils/parse-url-test.js
+++ b/packages/@pollyjs/core/tests/unit/utils/parse-url-test.js
@@ -13,4 +13,12 @@ describe('Unit | Utils | parseUrl', function() {
       'http://netflix.com/movies/1?sort=title&dir=asc'
     ].forEach(url => expect(parseUrl(url).href).to.equal(url));
   });
+
+  it('should passthrough arguments to url-parse', function() {
+    // Passing true tells url-parse to transform the querystring into an object
+    expect(parseUrl('/movies/1?sort=title&dir=asc', true).query).to.deep.equal({
+      sort: 'title',
+      dir: 'asc'
+    });
+  });
 });

--- a/packages/@pollyjs/core/tests/unit/utils/parse-url-test.js
+++ b/packages/@pollyjs/core/tests/unit/utils/parse-url-test.js
@@ -1,0 +1,16 @@
+import parseUrl from '../../../src/utils/parse-url';
+
+describe('Unit | Utils | parseUrl', function() {
+  it('should exist', function() {
+    expect(parseUrl).to.be.a('function');
+  });
+
+  it('should exactly match passed urls', function() {
+    [
+      '/movies/1',
+      '//netflix.com/movies/1',
+      'http://netflix.com/movies/1',
+      'http://netflix.com/movies/1?sort=title&dir=asc'
+    ].forEach(url => expect(parseUrl(url).href).to.equal(url));
+  });
+});

--- a/testem.js
+++ b/testem.js
@@ -20,8 +20,7 @@ module.exports = {
   serve_files: ['./packages/@pollyjs/*/build/browser/*.js'],
   browser_args: {
     Chrome: {
-      mode: 'ci',
-      args: [
+      ci: [
         // --no-sandbox is needed when running Chrome inside a container
         process.env.TRAVIS ? '--no-sandbox' : null,
         '--disable-gpu',


### PR DESCRIPTION
- Create a shared parseUrl utility that will make sure to match the provided URL string to a url-parse instance
- Support for protocol-relative URLs (Resolves #76)