### PR TITLE
 fix(adapter-puppeteer): Cors preflight requests

### DIFF
--- a/packages/@pollyjs/adapter-puppeteer/src/index.js
+++ b/packages/@pollyjs/adapter-puppeteer/src/index.js
@@ -44,8 +44,8 @@ export default class PuppeteerAdapter extends Adapter {
         if (requestResourceTypes.includes(request.resourceType())) {
           const headers = request.headers();
 
-          // A CORS preflight request is a CORS request that checks to see if the CORS protocol is understood.
-          // https://developer.mozilla.org/en-US/docs/Glossary/preflight_request
+          // A CORS preflight request is a CORS request that checks to see
+          // if the CORS protocol is understood.
           const isPreFlightReq =
             request.method() === 'OPTIONS' &&
             !!headers['origin'] &&

--- a/packages/@pollyjs/adapter-puppeteer/src/index.js
+++ b/packages/@pollyjs/adapter-puppeteer/src/index.js
@@ -43,9 +43,31 @@ export default class PuppeteerAdapter extends Adapter {
       request: request => {
         if (requestResourceTypes.includes(request.resourceType())) {
           const headers = request.headers();
+          const isPreFlight =
+            request.method() === 'OPTIONS' &&
+            !!headers['origin'] &&
+            !!headers['access-control-request-method'];
 
-          // If this is a polly passthrough request
-          if (headers[PASSTHROUGH_REQ_ID_HEADER]) {
+          if (
+            isPreFlight &&
+            (headers['access-control-request-headers'] || '').includes(
+              PASSTHROUGH_REQ_ID_HEADER
+            )
+          ) {
+            // If this is a preflight request and contains the polly passthrough
+            // header, then force allow the request.
+            request.respond({
+              status: 200,
+              headers: {
+                'Access-Control-Allow-Origin': headers['origin'],
+                'Access-Control-Allow-Method':
+                  headers['access-control-request-method'],
+                'Access-Control-Allow-Headers':
+                  headers['access-control-request-headers']
+              }
+            });
+          } else if (headers[PASSTHROUGH_REQ_ID_HEADER]) {
+            // If this is a polly passthrough request
             // Get the associated promise object for the request id and set it
             // on the request
             request[PASSTHROUGH_PROMISE] = this[PASSTHROUGH_PROMISES].get(
@@ -185,11 +207,18 @@ export default class PuppeteerAdapter extends Adapter {
           body
         });
       });
+      let responseBody;
+
+      try {
+        responseBody = await response.text();
+      } catch (error) {
+        // no-op
+      }
 
       return pollyRequest.respond(
         response.status(),
         response.headers(),
-        await response.text()
+        responseBody
       );
     } catch (error) {
       throw error;

--- a/tests/integration/adapter-tests.js
+++ b/tests/integration/adapter-tests.js
@@ -128,4 +128,16 @@ export default function adapterTests() {
     requests.forEach(request => expect(request.didRespond).to.be.true);
     expect(resolved).to.have.members([1, 2, 3]);
   });
+
+  it('should work with CORS requests', async function() {
+    const { server } = this.polly;
+    const apiUrl = 'https://aws.random.cat/meow';
+
+    server.get(apiUrl).passthrough();
+
+    const res = await this.fetch(apiUrl);
+
+    expect(res.ok).to.be.true;
+    expect(await res.json()).to.be.an('object');
+  });
 }


### PR DESCRIPTION
Resolves #87.

When making a CORS request, Chrome makes a [preflight request](https://developer.mozilla.org/en-US/docs/Glossary/preflight_request) to validate that the actual request will be accepted. Since the Puppeteer adapter is making a CORS pass-through request, we also have to intercept the preflight request so it doesnt go through the default adapter's request handler. Without the preflight intercept, the adapter goes into an infinite loop of making preflight requests until the browser crashes. 