### PR TITLE
fix: Allow 204 responses without a body

### DIFF
--- a/packages/@pollyjs/adapter-fetch/src/index.js
+++ b/packages/@pollyjs/adapter-fetch/src/index.js
@@ -87,9 +87,12 @@ export default class FetchAdapter extends Adapter {
     await pollyRequest.respond(status, headers, body);
 
     const { absoluteUrl, response } = pollyRequest;
+    const { statusCode } = response;
 
-    const fetchResponse = new Response(response.body, {
-      status: response.statusCode,
+    const responseBody =
+      statusCode === 204 && response.body === '' ? null : response.body;
+    const fetchResponse = new Response(responseBody, {
+      status: statusCode,
       headers: response.headers
     });
 


### PR DESCRIPTION
It turns out that 204 responses using fetch attempt to call `new Response`
with an empty string as a body, which is illegal and blows hard. The body
must be null.