### PR TITLE
feat(persister): Add `keepUnusedRequests` config option

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -223,7 +223,7 @@ _Default_: `false`
 
 When disabled, requests that have not been captured by the running Polly
 instance will be removed. This ensures that a recording will only contain the
-necessary requests that were made during the lifespan of the Polly instance.
+requests that were made during the lifespan of the Polly instance.
 When enabled, new requests will be appended to the recording file.
 
 __Example__

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -222,9 +222,10 @@ _Type_: `Boolean`
 _Default_: `false`
 
 When disabled, requests that have not been captured by the running Polly
-instance will be removed. This ensures that a recording will only contain the
-requests that were made during the lifespan of the Polly instance.
-When enabled, new requests will be appended to the recording file.
+instance will be removed from any previous recording. This ensures that a
+recording will only contain the requests that were made during the lifespan
+of the Polly instance. When enabled, new requests will be appended to the
+recording file.
 
 __Example__
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -216,6 +216,26 @@ polly.configure({
 });
 ```
 
+### keepUnusedRequests
+
+_Type_: `Boolean`
+_Default_: `false`
+
+When disabled, requests that have not been captured by the running Polly
+instance will be removed. This ensures that a recording will only contain the
+necessary requests that were made during the lifespan of the Polly instance.
+When enabled, new requests will be appended to the recording file.
+
+__Example__
+
+```js
+polly.configure({
+  persisterOptions: {
+    keepUnusedRequests: true
+  }
+});
+```
+
 ## timing
 
 _Type_: `Function`

--- a/packages/@pollyjs/core/src/defaults/config.js
+++ b/packages/@pollyjs/core/src/defaults/config.js
@@ -8,7 +8,9 @@ export default {
   adapterOptions: {},
 
   persister: null,
-  persisterOptions: {},
+  persisterOptions: {
+    keepUnusedRequests: false
+  },
 
   logging: false,
 

--- a/packages/@pollyjs/persister/src/index.js
+++ b/packages/@pollyjs/persister/src/index.js
@@ -180,6 +180,13 @@ export default class Persister {
     );
   }
 
+  /**
+   * Remove all entries from the given HAR that do not match any requests in
+   * the current Polly instance.
+   *
+   * @param {String} recordingId
+   * @param {HAR} har
+   */
   _removeUnusedEntries(recordingId, har) {
     const requests = this.polly._requests.filter(
       r =>

--- a/packages/@pollyjs/persister/src/index.js
+++ b/packages/@pollyjs/persister/src/index.js
@@ -1,7 +1,7 @@
 import HAR from './har';
 import Entry from './har/entry';
 import stringify from 'fast-json-stable-stringify';
-import { assert } from '@pollyjs/utils';
+import { ACTIONS, assert } from '@pollyjs/utils';
 
 const CREATOR_NAME = 'Polly.JS';
 
@@ -94,6 +94,18 @@ export default class Persister {
 
     await Promise.all(promises);
     this.pending.clear();
+  }
+
+  _removeUnusedEntries(recordingId, har) {
+    const requests = this.polly._requests.filter(
+      r =>
+        r.recordingId === recordingId &&
+        (r.action === ACTIONS.RECORD || r.action === ACTIONS.REPLAY)
+    );
+
+    har.log.entries = har.log.entries.filter(entry =>
+      requests.find(r => entry._id === r.id && entry._order === r.order)
+    );
   }
 
   recordRequest(pollyRequest) {


### PR DESCRIPTION
Currently by default, all new requests are appended to the currently existing recording HAR file. Although this works well (especially when using Polly for an offline only tool), it creates bloated recording files with unused requests. This PR handles the more generic case where a recording file should only contain the requests that have been captured by the running Polly instance. 

## Changes Proposed

### keepUnusedRequests _<sup>new</sup>_

 _Type_: `Boolean`
_Default_: `false`

When disabled, requests that have not been captured by the running Polly instance will be removed. This ensures that a recording will only contain the requests that were made during the lifespan of the Polly instance. When enabled, new requests will be appended to the recording file.

 __Example__

 ```js
polly.configure({
  persisterOptions: {
    keepUnusedRequests: true
  }
});
```