### PR TITLE
feat(core): Add setupJasmine test helper

### DIFF
--- a/packages/@pollyjs/core/src/index.js
+++ b/packages/@pollyjs/core/src/index.js
@@ -3,3 +3,4 @@ export { default as Timing } from './utils/timing';
 
 export { default as setupQunit } from './test-helpers/qunit';
 export { default as setupMocha } from './test-helpers/mocha';
+export { default as setupJasmine } from './test-helpers/jasmine';

--- a/packages/@pollyjs/core/src/test-helpers/jasmine.js
+++ b/packages/@pollyjs/core/src/test-helpers/jasmine.js
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach } from './lib';
+
+/**
+ * Flag, showing that Polly is active
+ */
+const IS_POLLY_ACTIVE = Symbol('IS_POLLY_ACTIVE');
+
+/**
+ * Flag, showing that proxy test methods are attached
+ */
+const IS_POLLY_ATTACHED = Symbol('IS_POLLY_ATTACHED');
+
+/**
+ * Shared context to keep polly instance and
+ * options for a specific run
+ */
+const pollyContext = {
+  polly: null,
+  options: {}
+};
+
+/**
+ * Get full spec description, starting from the top
+ * suite
+ *
+ * @param {Object} spec Current spec
+ * @param {Object} suite Current spec parent suite
+ *
+ * @returns {string} Full spec description (e.g. "suite/should do something")
+ */
+function getRecordingName(spec, suite) {
+  const descriptions = [spec.description];
+
+  while (suite) {
+    suite.description && descriptions.push(suite.description);
+    suite = suite.parentSuite;
+  }
+
+  return descriptions.reverse().join('/');
+}
+
+/**
+ * Recursively go through suite and its children
+ * and return the first that matches the findFn
+ * condition
+ *
+ * @param {Object} suite Starting point
+ * @param {Function} findFn Find function
+ *
+ * @returns {?Object} Matching suite or null
+ */
+function findSuiteRec(suite, findFn) {
+  if (findFn(suite)) return suite;
+
+  for (const child of suite.children || []) {
+    const result = findSuiteRec(child, findFn);
+
+    if (result !== null) {
+      return result;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Create proxy for jasmine test function that starts and
+ * stops Polly on before/after hooks
+ *
+ * @param {Function} fn Original test runner test function
+ * @param {Object} jasmineEnv Jasmine environment
+ *
+ * @returns {Function} Proxy function
+ */
+function createTestFnProxy(fn, jasmineEnv) {
+  return function testFn() {
+    const spec = fn.apply(jasmineEnv, arguments);
+    const specHooks = spec.beforeAndAfterFns;
+
+    spec.beforeAndAfterFns = function beforeAndAfterFns() {
+      const { befores, afters } = specHooks.apply(spec, arguments);
+
+      const before = async function before(done) {
+        if (jasmineEnv[IS_POLLY_ACTIVE]) {
+          const topSuite = jasmineEnv.topSuite();
+          const specParentSuite = findSuiteRec(topSuite, suite =>
+            (suite.children || []).some(child => child.id === spec.id)
+          );
+
+          let recordingName = getRecordingName(spec, specParentSuite);
+
+          // In jest top suite description is empty, in jasmine it is
+          // randomly generated string. We don't want it to be used
+          // as recording name if it exists
+          if (topSuite.description) {
+            recordingName = recordingName.replace(
+              `${topSuite.description}/`,
+              ''
+            );
+          }
+
+          await beforeEach(pollyContext, recordingName, pollyContext.options);
+        }
+
+        done && done();
+      };
+
+      const after = async function after(done) {
+        if (jasmineEnv[IS_POLLY_ACTIVE]) {
+          await afterEach(pollyContext, 'jasmine');
+        }
+
+        done && done();
+      };
+
+      return {
+        befores: [{ fn: before }].concat(befores),
+        afters: afters.concat({ fn: after })
+      };
+    };
+
+    return spec;
+  };
+}
+
+/**
+ * Attach test fn proxies to jasmine environment if needed and
+ * add beforeAll/afterAll hooks that will activate/deactivate
+ * Polly when running test suite
+ *
+ * @param {Object} defaults Polly default options
+ * @param {Object} ctx Global context
+ *
+ * @returns {Object} Context with `polly` property
+ */
+export default function setupJasmine(defaults = {}, ctx = global) {
+  if (
+    !ctx.jasmine ||
+    (ctx.jasmine && typeof ctx.jasmine.getEnv !== 'function')
+  ) {
+    throw new TypeError(
+      'Couldn\'t find jasmine environment. Make sure that you are using "setupJasmine" in ' +
+        'jasmine/jest environment or that you provided proper jasmine environment when calling "setupJasmine"'
+    );
+  }
+
+  const jasmineEnv = ctx.jasmine.getEnv();
+
+  pollyContext.options = defaults;
+
+  if (!jasmineEnv[IS_POLLY_ATTACHED]) {
+    jasmineEnv.it = createTestFnProxy(jasmineEnv.it, jasmineEnv);
+    jasmineEnv.fit = createTestFnProxy(jasmineEnv.fit, jasmineEnv);
+
+    jasmineEnv[IS_POLLY_ATTACHED] = true;
+    jasmineEnv[IS_POLLY_ACTIVE] = false;
+  }
+
+  ctx.beforeAll(() => {
+    jasmineEnv[IS_POLLY_ACTIVE] = true;
+  });
+
+  ctx.afterAll(() => {
+    jasmineEnv[IS_POLLY_ACTIVE] = false;
+  });
+
+  return {
+    get polly() {
+      return pollyContext.polly;
+    }
+  };
+}
+
+setupJasmine.IS_POLLY_ACTIVE = IS_POLLY_ACTIVE;
+
+setupJasmine.IS_POLLY_ATTACHED = IS_POLLY_ATTACHED;

--- a/packages/@pollyjs/core/tests/unit/index-test.js
+++ b/packages/@pollyjs/core/tests/unit/index-test.js
@@ -2,8 +2,10 @@ import * as PollyExports from '../../src';
 
 describe('Unit | Index', function() {
   it('should export all the necessary modules', function() {
-    ['Polly', 'Timing', 'setupQunit', 'setupMocha'].forEach(name => {
-      expect(PollyExports[name]).to.be.ok;
-    });
+    ['Polly', 'Timing', 'setupQunit', 'setupMocha', 'setupJasmine'].forEach(
+      name => {
+        expect(PollyExports[name]).to.be.ok;
+      }
+    );
   });
 });

--- a/packages/@pollyjs/core/tests/unit/test-helpers/jasmine-test.js
+++ b/packages/@pollyjs/core/tests/unit/test-helpers/jasmine-test.js
@@ -1,0 +1,168 @@
+import setupPolly from '../../../src/test-helpers/jasmine';
+
+class JasmineMock {
+  constructor() {
+    this.topSuite = {
+      id: 'suite0',
+      description: 'root suite with unreadable description',
+      parentSuite: null,
+      children: [
+        {
+          id: 'suite1',
+          description: 'suite1',
+          parentSuite: null,
+          children: [
+            {
+              id: 'special_test_id_to_test_name_generation',
+              description: 'test case',
+              parentSuite: null
+            }
+          ]
+        }
+      ]
+    };
+
+    this.topSuite.children[0].parentSuite = this.topSuite;
+    this.topSuite.children[0].children[0].parentSuite = this.topSuite.children[0];
+
+    this.it = name => ({
+      id: name,
+      description: name,
+      beforeAndAfterFns: () => ({ befores: [], afters: [] })
+    });
+
+    this.env = { it: this.it, fit: this.it, topSuite: () => this.topSuite };
+
+    this.getEnv = () => this.env;
+  }
+}
+
+class ContextMock {
+  constructor() {
+    this.before = new Set();
+    this.after = new Set();
+
+    this.jasmine = new JasmineMock();
+  }
+
+  beforeAll(fn) {
+    this.before.add(fn);
+  }
+
+  __callBefore() {
+    this.before.forEach(fn => fn());
+  }
+
+  afterAll(fn) {
+    this.after.add(fn);
+  }
+
+  __callAfter() {
+    this.after.forEach(fn => fn());
+  }
+}
+
+describe.only('Unit | Test Helpers | jasmine', () => {
+  it('should throw if jasmine is not found in context', () => {
+    expect(() => setupPolly({}, null)).to.throw();
+  });
+
+  it('should attach polly to jasmine environment', () => {
+    const stub = new ContextMock();
+    const env = stub.jasmine.getEnv();
+
+    expect(env[setupPolly.IS_POLLY_ATTACHED]).to.be.undefined;
+
+    setupPolly({}, stub);
+
+    expect(env[setupPolly.IS_POLLY_ATTACHED]).to.equal(true);
+  });
+
+  it('should add beforeAll and afterAll hooks', () => {
+    const stub = new ContextMock();
+
+    setupPolly({}, stub);
+
+    expect(stub.before.size).to.equal(1);
+    expect(stub.after.size).to.equal(1);
+  });
+
+  it('should proxy jasmine `it` and `fit` env methods', () => {
+    const stub = new ContextMock();
+
+    setupPolly({}, stub);
+
+    expect(stub.jasmine.getEnv().it).not.to.equal(stub.jasmine.it);
+
+    const spec = stub.jasmine.getEnv().it('test case name');
+
+    expect(spec).to.have.property('id', 'test case name');
+    expect(spec).to.have.property('description', 'test case name');
+    expect(spec).to.have.property('beforeAndAfterFns');
+  });
+
+  it('should activate polly when beforeAll hook is called', () => {
+    const stub = new ContextMock();
+    const env = stub.jasmine.getEnv();
+
+    setupPolly({}, stub);
+
+    expect(env[setupPolly.IS_POLLY_ACTIVE]).to.equal(false);
+
+    stub.__callBefore();
+
+    expect(env[setupPolly.IS_POLLY_ACTIVE]).to.equal(true);
+  });
+
+  it('should deactivate polly when afterAll hook is called', () => {
+    const stub = new ContextMock();
+    const env = stub.jasmine.getEnv();
+
+    setupPolly({}, stub);
+
+    stub.__callBefore();
+
+    expect(env[setupPolly.IS_POLLY_ACTIVE]).to.equal(true);
+
+    stub.__callAfter();
+
+    expect(env[setupPolly.IS_POLLY_ACTIVE]).to.equal(false);
+  });
+
+  it('should create new polly instance if polly is active', async () => {
+    const stub = new ContextMock();
+
+    const context = setupPolly({}, stub);
+
+    stub.__callBefore();
+
+    const spec = stub.jasmine.getEnv().it('test case name');
+
+    const { befores } = spec.beforeAndAfterFns();
+
+    await befores[0].fn();
+
+    expect(context.polly).to.be.ok;
+    expect(context.polly.recordingName).to.equal('test case name');
+  });
+
+  it('should create nested name for the test', async () => {
+    const stub = new ContextMock();
+
+    const context = setupPolly({}, stub);
+
+    stub.__callBefore();
+
+    const spec = stub.jasmine
+      .getEnv()
+      .it('special_test_id_to_test_name_generation');
+
+    const { befores } = spec.beforeAndAfterFns();
+
+    await befores[0].fn();
+
+    expect(context.polly.recordingName).to.equal(
+      'suite1/special_test_id_to_test_name_generation'
+    );
+  });
+});


### PR DESCRIPTION
⚠️ This PR is WIP

This is a follow-up to the discussion in #116. I made some slight changes to the code compared to the initial implementation to make it closer to the code style of this repo, but other than that this is basically a port of what was implemented already in https://github.com/gribnoysup/setup-polly-jest

I wanted to open PR as soon as the initial implementation is there so you can see the progress, but there are a couple of things that I feel are needed before this can be considered done:

- [x] implement `setupJasmine` helper method
- [x] basic unit tests
- [ ] integration tests for `jest`
- [ ] integration tests for `jasmine` (?)
- [ ] documentation
- [ ] update examples that are using `jest`

If you feel that something on that list is unnecessary or should be done separately, please let me know 😸 

Sorry for the delay with PR, running tests locally wasn't working properly for me at first so it was hard to test the implementation 😅

Closes #116 