### PR TITLE
fix(core): Support URL objects

### DIFF
--- a/examples/jest-node-fetch/__mocks__/node-fetch/index.js
+++ b/examples/jest-node-fetch/__mocks__/node-fetch/index.js
@@ -11,15 +11,7 @@ global.Headers = Headers;
 
 // Use global fetch as a mock. It will be
 // the one overwritten by polly
-const mock = (url, options) => {
-  return global.fetch(
-    // Polly doesn't support URL objects with fetch
-    // adapter, we will work around it by stringifying
-    // the passed URL
-    url.toString(),
-    options
-  );
-};
+const mock = (url, options) => global.fetch(url, options);
 
 mock.Request = Request;
 mock.Response = Response;

--- a/packages/@pollyjs/adapter-fetch/tests/browser/integration/adapter-test.js
+++ b/packages/@pollyjs/adapter-fetch/tests/browser/integration/adapter-test.js
@@ -5,6 +5,7 @@ import adapterBrowserTests from '@pollyjs-tests/integration/adapter-browser-test
 import RESTPersister from '@pollyjs/persister-rest';
 
 import FetchAdapter from '../../../src';
+import commonTests from '../../common-tests';
 
 describe('Integration | Fetch Adapter | Browser', function() {
   setupPolly.beforeEach({
@@ -21,4 +22,5 @@ describe('Integration | Fetch Adapter | Browser', function() {
 
   adapterTests();
   adapterBrowserTests();
+  commonTests();
 });

--- a/packages/@pollyjs/adapter-fetch/tests/common-tests.js
+++ b/packages/@pollyjs/adapter-fetch/tests/common-tests.js
@@ -1,0 +1,13 @@
+import { URL } from '@pollyjs/utils';
+
+export default function commonTests() {
+  it('should support URL instances', async function() {
+    const { server } = this.polly;
+
+    server.any(this.recordUrl()).intercept((_, res) => res.sendStatus(200));
+
+    const res = await this.fetch(new URL(this.recordUrl()));
+
+    expect(res.status).to.equal(200);
+  });
+}

--- a/packages/@pollyjs/adapter-fetch/tests/node/integration/adapter-test.js
+++ b/packages/@pollyjs/adapter-fetch/tests/node/integration/adapter-test.js
@@ -6,6 +6,7 @@ import FSPersister from '@pollyjs/persister-fs';
 import { setupMocha as setupPolly } from '@pollyjs/core';
 
 import FetchAdapter from '../../../src';
+import commonTests from '../../common-tests';
 
 describe('Integration | Fetch Adapter | Node', function() {
   setupPolly.beforeEach({
@@ -21,4 +22,5 @@ describe('Integration | Fetch Adapter | Node', function() {
   setupPolly.afterEach();
 
   adapterTests();
+  commonTests();
 });

--- a/packages/@pollyjs/core/src/-private/request.js
+++ b/packages/@pollyjs/core/src/-private/request.js
@@ -27,8 +27,11 @@ export default class PollyRequest extends HTTPBase {
   constructor(polly, request) {
     super();
 
-    assert('Url is required.', typeof request.url === 'string');
-    assert('Method is required.', typeof request.method === 'string');
+    assert('Url is required.', request.url);
+    assert(
+      'Method is required.',
+      request.method && typeof request.method === 'string'
+    );
 
     this.didRespond = false;
     this.url = request.url;
@@ -68,7 +71,9 @@ export default class PollyRequest extends HTTPBase {
   }
 
   set url(value) {
-    this[PARSED_URL] = parseUrl(value, true);
+    // Make sure to coerce the value into a string as the passed value could be
+    // a WHATWG's URL object.
+    this[PARSED_URL] = parseUrl(`${value}`, true);
   }
 
   get absoluteUrl() {


### PR DESCRIPTION
Make sure we coerce the passed url into a string so we can support Node or Node-like URL objects.