### PR TITLE
fix(core): Ignore `context` options from being deep merged

### DIFF
--- a/packages/@pollyjs/adapter-fetch/tests/integration/adapter-test.js
+++ b/packages/@pollyjs/adapter-fetch/tests/integration/adapter-test.js
@@ -8,10 +8,11 @@ describe('Integration | Fetch Adapter', function() {
   describe('Context', function() {
     it(`should assign context's fetch as the native fetch`, async function() {
       const polly = new Polly('context', { adapters: [] });
+      const fetch = () => {};
       const adapterOptions = {
         fetch: {
           context: {
-            fetch() {},
+            fetch,
             Response: MockResponse
           }
         }
@@ -22,16 +23,15 @@ describe('Integration | Fetch Adapter', function() {
         adapterOptions
       });
 
-      expect(polly.adapters.get('fetch').native).to.equal(
+      expect(polly.adapters.get('fetch').native).to.equal(fetch);
+      expect(polly.adapters.get('fetch').native).to.not.equal(
         adapterOptions.fetch.context.fetch
       );
 
       expect(function() {
         polly.configure({
           adapterOptions: {
-            fetch: {
-              context: undefined
-            }
+            fetch: { context: {} }
           }
         });
       }).to.throw(/Fetch global not found/);

--- a/packages/@pollyjs/core/package.json
+++ b/packages/@pollyjs/core/package.json
@@ -50,7 +50,6 @@
     "fast-json-stable-stringify": "^2.0.0",
     "is-absolute-url": "^2.1.0",
     "lodash-es": "^4.17.11",
-    "merge-options": "^1.0.1",
     "route-recognizer": "^0.3.4",
     "slugify": "^1.3.3"
   },

--- a/packages/@pollyjs/core/src/-private/request.js
+++ b/packages/@pollyjs/core/src/-private/request.js
@@ -1,12 +1,12 @@
 import md5 from 'blueimp-md5';
 import stringify from 'fast-json-stable-stringify';
-import mergeOptions from 'merge-options';
 import isAbsoluteUrl from 'is-absolute-url';
 import { URL, assert, timestamp } from '@pollyjs/utils';
 
 import NormalizeRequest from '../utils/normalize-request';
 import parseUrl from '../utils/parse-url';
 import guidForRecording from '../utils/guid-for-recording';
+import mergeConfigs from '../utils/merge-configs';
 import defer from '../utils/deferred-promise';
 import {
   validateRecordingName,
@@ -204,7 +204,7 @@ export default class PollyRequest extends HTTPBase {
 
   _configure(config) {
     validateRequestConfig(config);
-    this.config = mergeOptions(this[POLLY].config, this.config || {}, config);
+    this.config = mergeConfigs(this[POLLY].config, this.config || {}, config);
   }
 
   _intercept() {

--- a/packages/@pollyjs/core/src/polly.js
+++ b/packages/@pollyjs/core/src/polly.js
@@ -1,4 +1,3 @@
-import mergeOptions from 'merge-options';
 import { MODES, assert } from '@pollyjs/utils';
 
 import { version } from '../package.json';
@@ -8,6 +7,7 @@ import Container from './-private/container';
 import DefaultConfig from './defaults/config';
 import PollyRequest from './-private/request';
 import guidForRecording from './utils/guid-for-recording';
+import mergeConfigs from './utils/merge-configs';
 import EventEmitter from './-private/event-emitter';
 import Server from './server';
 import { validateRecordingName } from './utils/validators';
@@ -159,7 +159,7 @@ export default class Polly {
     // Disconnect from all current adapters before updating the config
     this.disconnect();
 
-    this.config = mergeOptions(DefaultConfig, this.config, config);
+    this.config = mergeConfigs(DefaultConfig, this.config, config);
 
     // Register and connect to all specified adapters
     this.config.adapters.forEach(adapter => this.connectTo(adapter));

--- a/packages/@pollyjs/core/src/server/route.js
+++ b/packages/@pollyjs/core/src/server/route.js
@@ -1,4 +1,4 @@
-import mergeOptions from 'merge-options';
+import mergeConfigs from '../utils/merge-configs';
 
 async function invoke(fn, route, req, ...args) {
   if (typeof fn !== 'function') {
@@ -70,7 +70,7 @@ export default class Route {
   }
 
   config() {
-    return mergeOptions(
+    return mergeConfigs(
       ...this._orderedHandlers().map(handler => handler.get('config'))
     );
   }

--- a/packages/@pollyjs/core/src/utils/merge-configs.js
+++ b/packages/@pollyjs/core/src/utils/merge-configs.js
@@ -1,0 +1,13 @@
+import mergeWith from 'lodash-es/mergeWith';
+
+function customizer(objValue, srcValue, key) {
+  // Arrays and `context` options should just replace the existing value
+  // and not be deep merged.
+  if (Array.isArray(objValue) || ['context'].includes(key)) {
+    return srcValue;
+  }
+}
+
+export default function mergeConfigs(...configs) {
+  return mergeWith({}, ...configs, customizer);
+}

--- a/packages/@pollyjs/core/tests/unit/utils/merge-configs-test.js
+++ b/packages/@pollyjs/core/tests/unit/utils/merge-configs-test.js
@@ -1,0 +1,28 @@
+import mergeConfigs from '../../../src/utils/merge-configs';
+
+describe('Unit | Utils | mergeConfigs', function() {
+  it('should exist', function() {
+    expect(mergeConfigs).to.be.a('function');
+  });
+
+  it('should not deep merge context objects', async function() {
+    const context = {};
+    const config = mergeConfigs(
+      { fetch: {}, xhr: {} },
+      { fetch: { context } },
+      { xhr: { context } },
+      { fetch: {}, xhr: {} }
+    );
+
+    expect(config.fetch.context).to.equal(context);
+    expect(config.xhr.context).to.equal(context);
+  });
+
+  it('should not deep merge arrays', async function() {
+    const array = [{}];
+    const config = mergeConfigs({ array: [] }, { array });
+
+    expect(config.array).to.equal(array);
+    expect(config.array[0]).to.equal(array[0]);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -7828,7 +7828,7 @@ is-path-inside@^1.0.0:
   dependencies:
     path-is-inside "^1.0.1"
 
-is-plain-obj@^1.0.0, is-plain-obj@^1.1, is-plain-obj@^1.1.0:
+is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
 
@@ -9584,12 +9584,6 @@ meow@^4.0.0:
 merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
-
-merge-options@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/merge-options/-/merge-options-1.0.1.tgz#2a64b24457becd4e4dc608283247e94ce589aa32"
-  dependencies:
-    is-plain-obj "^1.1"
 
 merge-stream@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Resolves #143.