### PR TITLE
Simplify adapter implementation

### DIFF
--- a/packages/@pollyjs/adapter-node-http/src/index.js
+++ b/packages/@pollyjs/adapter-node-http/src/index.js
@@ -35,36 +35,13 @@ export default class HttpAdapter extends Adapter {
     }
   }
 
-  async onRecord(pollyRequest) {
-    await this.passthroughRequest(pollyRequest);
-    await this.persister.recordRequest(pollyRequest);
-    await this.respond(pollyRequest);
-  }
-
-  async onReplay(pollyRequest, { statusCode, headers, body }) {
-    await pollyRequest.respond(statusCode, headers, body);
-
-    await this.respond(pollyRequest);
-  }
-
-  async onPassthrough(pollyRequest) {
-    await this.passthroughRequest(pollyRequest);
-    await this.respond(pollyRequest);
-  }
-
-  async onIntercept(pollyRequest, { statusCode, headers, body }) {
-    await pollyRequest.respond(statusCode, headers, body);
-    await this.respond(pollyRequest);
-  }
-
   async passthroughRequest(pollyRequest) {
     const [transportWrapper] = pollyRequest.requestArguments;
-    const res = await transportWrapper.passthrough(pollyRequest);
 
-    await pollyRequest.respond(res.statusCode, res.headers, res.body);
+    return transportWrapper.passthrough(pollyRequest);
   }
 
-  async respond(pollyRequest) {
+  async respondToRequest(pollyRequest) {
     const [transportWrapper] = pollyRequest.requestArguments;
 
     return transportWrapper.respond(pollyRequest);

--- a/packages/@pollyjs/adapter/src/index.js
+++ b/packages/@pollyjs/adapter/src/index.js
@@ -98,11 +98,10 @@ export default class Adapter {
     await this.onRequest(pollyRequest);
 
     try {
-      const result = await this[REQUEST_HANDLER](pollyRequest);
+      await this[REQUEST_HANDLER](pollyRequest);
+      await this.onRequestFinished(pollyRequest);
 
-      await this.onRequestFinished(pollyRequest, result);
-
-      return result;
+      return pollyRequest;
     } catch (error) {
       await this.onRequestFailed(pollyRequest, error);
       throw error;
@@ -229,10 +228,20 @@ export default class Adapter {
 
   /**
    * @param {PollyRequest} pollyRequest
+   * @returns {response}
+   */
+  async passthroughRequest(/* pollyRequest */) {
+    this.assert('Must implement `passthroughRequest`.', false);
+  }
+
+  /* Other Hooks */
+  /**
+   * @param {PollyRequest} pollyRequest
    * @returns {*}
    */
-  onRecord() {
-    this.assert('Must implement the `onRecord` hook.', false);
+  async onRecord(pollyRequest) {
+    await this.onPassthrough(pollyRequest);
+    await this.persister.recordRequest(pollyRequest);
   }
 
   /**
@@ -241,8 +250,8 @@ export default class Adapter {
    * @param {Object} recordingEntry The entire recording entry
    * @returns {*}
    */
-  onReplay() {
-    this.assert('Must implement the `onReplay` hook.', false);
+  async onReplay(pollyRequest, { statusCode, headers, body }) {
+    await pollyRequest.respond(statusCode, headers, body);
   }
 
   /**
@@ -250,19 +259,22 @@ export default class Adapter {
    * @param {PollyResponse} response
    * @returns {*}
    */
-  onIntercept() {
-    this.assert('Must implement the `onIntercept` hook.', false);
+  async onIntercept(pollyRequest, { statusCode, headers, body }) {
+    await pollyRequest.respond(statusCode, headers, body);
   }
 
   /**
    * @param {PollyRequest} pollyRequest
    * @returns {*}
    */
-  onPassthrough() {
-    this.assert('Must implement the `onPassthrough` hook.', false);
+  async onPassthrough(pollyRequest) {
+    const { statusCode, headers, body } = await this.passthroughRequest(
+      pollyRequest
+    );
+
+    await pollyRequest.respond(statusCode, headers, body);
   }
 
-  /* Other Hooks */
   /**
    * @param {PollyRequest} pollyRequest
    */
@@ -284,8 +296,10 @@ export default class Adapter {
    * @param {PollyRequest} pollyRequest
    * @param {*} result The returned result value from the request handler
    */
-  onRequestFinished(pollyRequest, result) {
-    pollyRequest.promise.resolve(result);
+  async onRequestFinished(pollyRequest) {
+    await this.respondToRequest(pollyRequest);
+
+    pollyRequest.promise.resolve();
   }
 
   /**
@@ -295,4 +309,12 @@ export default class Adapter {
   onRequestFailed(pollyRequest, error) {
     pollyRequest.promise.reject(error);
   }
+
+  /**
+   * Make sure the response from a Polly request is delivered to the
+   * user through the adapter interface.
+   *
+   * Calling `pollyjs.flush()` waill await this method.
+   */
+  async respondToRequest(/* pollyRequest */) {}
 }

--- a/packages/@pollyjs/adapter/src/index.js
+++ b/packages/@pollyjs/adapter/src/index.js
@@ -314,7 +314,7 @@ export default class Adapter {
    * Make sure the response from a Polly request is delivered to the
    * user through the adapter interface.
    *
-   * Calling `pollyjs.flush()` waill await this method.
+   * Calling `pollyjs.flush()` will await this method.
    */
   async respondToRequest(/* pollyRequest */) {}
 }


### PR DESCRIPTION
This is a proof of concept for a simplified `Adapter` class that should make it easier to implement existing and custom adapters. I’d like to get feedback on this proposal and continue working on it if it looks good.

### Motivation

The motivation behind this is to make it easier to implement custom adapters. This is something I struggled with when trying to write an adapter that integrates with Cypress. The documentation on how to write custom adapters is sparse so I had to dig into the code.
1. The number of methods one needs to implement is quite large. (`onConnect`, `onDisconnect`, `onIntercept`, `onPassthrough`, `onRecord`, `onReplay`)
2. One needs to include code to persist the request in `onRecord`. If the implementer forgets this, recording will not work.
3. One needs to manually call `pollyRequest.responds()` in some hooks. Again, if this is omitted, the adapter will break.
4. Almost all request hooks call the same code at the end. (There are some exceptions but they just seem to be inconsistencies.)
5. The return value of the request hooks is returned by `handleRequest()`. This is not documented, hard to understand, and couples the request hook very tightly.

### Proposal

The proposal addresses the five problems above by introducing a new `SimpleAdapter` class that can be used to implement adapters. This class requires the implementer to provide only three methods (`onConnect`, `onDisconnect`, and `passthroughRequest`). Using the `SimpleAdapter` allows for smaller and less complex adapter implementations.

`SimpleAdapter` extends the `Adapter` class. The original is retained for backwards compatibility.

### Todo

- [x] Flesh out docs for implementing custom adapter
- [x] Implement puppeteer and node-http adapters with `SimpleAdapter`