### PR TITLE
chore: Remove support for Node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - '6'
   - '8'
   - '10'
 

--- a/build-scripts/rollup.node.config.js
+++ b/build-scripts/rollup.node.config.js
@@ -29,7 +29,7 @@ export default function createNodeConfig(options = {}) {
               {
                 modules: false,
                 targets: {
-                  node: '6.0.0'
+                  node: '8.0.0'
                 }
               }
             ]

--- a/tests/integration/adapter-tests.js
+++ b/tests/integration/adapter-tests.js
@@ -167,6 +167,8 @@ export default function adapterTests() {
   });
 
   it('should work with CORS requests', async function() {
+    this.timeout(10000);
+
     const { server } = this.polly;
     const apiUrl = 'http://jsonplaceholder.typicode.com';
 


### PR DESCRIPTION
Node 6 is coming to EOL on April 2019 and our build is already failing due to dependencies dropping support for it as well. To allow simpler implementations on the Node side of Polly, I believe we should drop support of Node 6 as well as it will no longer be maintained in ~3 months. 