### PR TITLE
feat(core): Add removeHeader, removeHeaders, and allow empty headers

### DIFF
--- a/docs/server/request.md
+++ b/docs/server/request.md
@@ -19,7 +19,7 @@ req.getHeader('Content-Type'); // → application/json
 
 ### setHeader
 
-Set a header with a given name. If the value is falsy, the header will be
+Set a header with a given name. If the value is `null` or `undefined`, the header will be
 removed.
 
 | Param       | Type                      | Description              |
@@ -36,8 +36,8 @@ req.setHeader('Content-Length', 42);
 
 ### setHeaders
 
-Add multiple headers at once. A falsy header value will remove that header
-altogether.
+Add multiple headers at once. If a value is `null` or `undefined`, the header will be
+removed.
 
 | Param       | Type                      | Description                       |
 | ----------- | ------------------------- | --------------------------------- |
@@ -51,6 +51,36 @@ req.setHeaders({
   'Content-Type': 'application/json',
   'Content-Length': 42
 });
+```
+
+### removeHeader
+
+Remove a header with the given name.
+
+| Param       | Type                      | Description            |
+| ----------- | ------------------------- | ---------------------- |
+| name        | `String`                  | The name of the header |
+| **Returns** | [Request](server/request) | The current request    |
+
+**Example**
+
+```js
+req.removeHeader('Content-Length');
+```
+
+### removeHeaders
+
+Remove multiple headers at once.
+
+| Param       | Type                      | Description                            |
+| ----------- | ------------------------- | -------------------------------------- |
+| headers     | `Array`                   | The headers to remove from the request |
+| **Returns** | [Request](server/request) | The current request                    |
+
+**Example**
+
+```js
+req.removeHeaders(['Content-Type' 'Content-Length']);
 ```
 
 ### hasHeader

--- a/docs/server/response.md
+++ b/docs/server/response.md
@@ -69,7 +69,7 @@ removed.
 **Example**
 
 ```js
-req.setHeader('Content-Length', 42);
+res.setHeader('Content-Length', 42);
 ```
 
 ### setHeaders
@@ -85,7 +85,7 @@ removed.
 **Example**
 
 ```js
-req.setHeaders({
+res.setHeaders({
   'Content-Type': 'application/json',
   'Content-Length': 42
 });
@@ -103,7 +103,7 @@ Remove a header with the given name.
 **Example**
 
 ```js
-req.removeHeader('Content-Length');
+res.removeHeader('Content-Length');
 ```
 
 ### removeHeaders
@@ -118,7 +118,7 @@ Remove multiple headers at once.
 **Example**
 
 ```js
-req.removeHeaders(['Content-Type' 'Content-Length']);
+res.removeHeaders(['Content-Type' 'Content-Length']);
 ```
 
 ### hasHeader

--- a/docs/server/response.md
+++ b/docs/server/response.md
@@ -57,7 +57,7 @@ res.getHeader('Content-Type'); // → application/json
 
 ### setHeader
 
-Set a header with a given name. If the value is falsy, the header will be
+Set a header with a given name. If the value is `null` or `undefined`, the header will be
 removed.
 
 | Param       | Type                        | Description              |
@@ -69,26 +69,56 @@ removed.
 **Example**
 
 ```js
-res.setHeader('Content-Length', 42);
+req.setHeader('Content-Length', 42);
 ```
 
 ### setHeaders
 
-Add multiple headers at once. A falsy header value will remove that header
-altogether.
+Add multiple headers at once. If a value is `null` or `undefined`, the header will be
+removed.
 
-| Param       | Type                        | Description                        |
-| ----------- | --------------------------- | ---------------------------------- |
-| headers     | `Object`                    | The headers to add to the response |
-| **Returns** | [Response](server/response) | The current response               |
+| Param       | Type                        | Description                       |
+| ----------- | --------------------------- | --------------------------------- |
+| headers     | `Object`                    | The headers to add to the request |
+| **Returns** | [Response](server/response) | The current response              |
 
 **Example**
 
 ```js
-res.setHeaders({
+req.setHeaders({
   'Content-Type': 'application/json',
   'Content-Length': 42
 });
+```
+
+### removeHeader
+
+Remove a header with the given name.
+
+| Param       | Type                        | Description            |
+| ----------- | --------------------------- | ---------------------- |
+| name        | `String`                    | The name of the header |
+| **Returns** | [Response](server/response) | The current response   |
+
+**Example**
+
+```js
+req.removeHeader('Content-Length');
+```
+
+### removeHeaders
+
+Remove multiple headers at once.
+
+| Param       | Type                        | Description                            |
+| ----------- | --------------------------- | -------------------------------------- |
+| headers     | `Array`                     | The headers to remove from the request |
+| **Returns** | [Response](server/response) | The current response                   |
+
+**Example**
+
+```js
+req.removeHeaders(['Content-Type' 'Content-Length']);
 ```
 
 ### hasHeader

--- a/docs/server/response.md
+++ b/docs/server/response.md
@@ -77,10 +77,10 @@ res.setHeader('Content-Length', 42);
 Add multiple headers at once. If a value is `null` or `undefined`, the header will be
 removed.
 
-| Param       | Type                        | Description                       |
-| ----------- | --------------------------- | --------------------------------- |
-| headers     | `Object`                    | The headers to add to the request |
-| **Returns** | [Response](server/response) | The current response              |
+| Param       | Type                        | Description                        |
+| ----------- | --------------------------- | ---------------------------------- |
+| headers     | `Object`                    | The headers to add to the response |
+| **Returns** | [Response](server/response) | The current response               |
 
 **Example**
 
@@ -110,10 +110,10 @@ res.removeHeader('Content-Length');
 
 Remove multiple headers at once.
 
-| Param       | Type                        | Description                            |
-| ----------- | --------------------------- | -------------------------------------- |
-| headers     | `Array`                     | The headers to remove from the request |
-| **Returns** | [Response](server/response) | The current response                   |
+| Param       | Type                        | Description                             |
+| ----------- | --------------------------- | --------------------------------------- |
+| headers     | `Array`                     | The headers to remove from the response |
+| **Returns** | [Response](server/response) | The current response                    |
 
 **Example**
 

--- a/packages/@pollyjs/core/src/-private/http-base.js
+++ b/packages/@pollyjs/core/src/-private/http-base.js
@@ -28,6 +28,20 @@ export default class HTTPBase {
     return this;
   }
 
+  removeHeader(name) {
+    this.setHeader(name, null);
+
+    return this;
+  }
+
+  removeHeaders(headers = []) {
+    for (const name of headers) {
+      this.removeHeader(name);
+    }
+
+    return this;
+  }
+
   hasHeader(name) {
     return !!this.getHeader(name);
   }

--- a/packages/@pollyjs/core/src/utils/http-headers.js
+++ b/packages/@pollyjs/core/src/utils/http-headers.js
@@ -13,11 +13,21 @@ const HANDLER = {
       return false;
     }
 
-    if (!value) {
+    if (value === null || typeof value === 'undefined') {
       delete obj[prop.toLowerCase()];
     } else {
       obj[prop.toLowerCase()] = value;
     }
+
+    return true;
+  },
+
+  deleteProperty(obj, prop) {
+    if (typeof prop !== 'string') {
+      return false;
+    }
+
+    delete obj[prop.toLowerCase()];
 
     return true;
   }

--- a/packages/@pollyjs/core/tests/unit/-private/http-base-test.js
+++ b/packages/@pollyjs/core/tests/unit/-private/http-base-test.js
@@ -25,7 +25,7 @@ describe('Unit | HTTPBase', function() {
       expect(base.getHeader('one')).to.equal('1');
       expect(base.getHeader('Two')).to.be.undefined;
 
-      base.setHeader('One', '');
+      base.removeHeader('One');
       expect(base.getHeader('One')).to.be.undefined;
       expect(base.getHeader('one')).to.be.undefined;
     });
@@ -40,7 +40,7 @@ describe('Unit | HTTPBase', function() {
       expect(base.hasHeader('one')).to.be.true;
       expect(base.hasHeader('Two')).to.be.false;
 
-      base.setHeader('One', '');
+      base.removeHeader('One');
       expect(base.hasHeader('One')).to.be.false;
       expect(base.hasHeader('one')).to.be.false;
     });
@@ -54,7 +54,7 @@ describe('Unit | HTTPBase', function() {
       base.setHeader('two', '2');
       expect(headers).to.deep.equal({ one: '1', two: '2' });
 
-      base.setHeader('Two', '');
+      base.setHeader('Two', null);
       expect(headers).to.deep.equal({ one: '1' });
     });
 
@@ -67,8 +67,29 @@ describe('Unit | HTTPBase', function() {
       base.setHeaders({ Three: '3' });
       expect(headers).to.deep.equal({ one: '1', two: '2', three: '3' });
 
-      base.setHeaders({ Three: '' });
+      base.setHeaders({ Three: null });
       expect(headers).to.deep.equal({ one: '1', two: '2' });
+    });
+
+    it('.removeHeader()', function() {
+      const { headers } = base;
+
+      base.setHeaders({ One: '1', Two: '2' });
+
+      base.removeHeader('One');
+      expect(headers).to.deep.equal({ two: '2' });
+
+      base.removeHeader('two');
+      expect(headers).to.deep.equal({});
+    });
+
+    it('.removeHeaders()', function() {
+      const { headers } = base;
+
+      base.setHeaders({ One: '1', Two: '2' });
+
+      base.removeHeaders(['One', 'two']);
+      expect(headers).to.deep.equal({});
     });
 
     it('.type()', function() {

--- a/packages/@pollyjs/core/tests/unit/utils/http-headers-test.js
+++ b/packages/@pollyjs/core/tests/unit/utils/http-headers-test.js
@@ -28,13 +28,43 @@ describe('Unit | Utils | HTTPHeaders', function() {
     expect(headers['CONTENT-TYPE']).to.equal('application/json');
   });
 
-  it('should delete header when set with a falsy value', function() {
+  it('should allow an empty header value', function() {
+    const headers = new HTTPHeaders();
+
+    headers['Content-Type'] = '';
+
+    expect(headers['Content-Type']).to.equal('');
+  });
+
+  it('should delete header regardless of case', function() {
+    const headers = new HTTPHeaders();
+
+    headers['Content-Type'] = 'application/json';
+    expect(keys(headers)).to.deep.equal(['content-type']);
+
+    delete headers['Content-Type'];
+    expect(keys(headers)).to.deep.equal([]);
+
+    headers['Content-Type'] = 'application/json';
+    expect(keys(headers)).to.deep.equal(['content-type']);
+
+    delete headers['CONTENT-TYPE'];
+    expect(keys(headers)).to.deep.equal([]);
+  });
+
+  it('should delete header when set with a null/undefined value', function() {
     const headers = new HTTPHeaders();
 
     headers['Content-Type'] = 'application/json';
     expect(keys(headers)).to.deep.equal(['content-type']);
 
     headers['Content-Type'] = null;
+    expect(keys(headers)).to.deep.equal([]);
+
+    headers['Content-Type'] = 'application/json';
+    expect(keys(headers)).to.deep.equal(['content-type']);
+
+    headers['Content-Type'] = undefined;
     expect(keys(headers)).to.deep.equal([]);
   });
 
@@ -48,5 +78,11 @@ describe('Unit | Utils | HTTPHeaders', function() {
     const headers = new HTTPHeaders();
 
     expect(() => (headers[Symbol()] = 'Foo')).to.throw(TypeError);
+  });
+
+  it('should not allow deleting a non string header key', function() {
+    const headers = new HTTPHeaders();
+
+    expect(() => delete headers[Symbol()]).to.throw(TypeError);
   });
 });


### PR DESCRIPTION
1. Add `removeHeader` and `removeHeaders` API. This is a lot more intuitive than `setHeader('Content-Type', null).
2. Support setting empty header values as the `Host` header can be an empty string.
3. Support for deleting a header property via `delete header[prop]` where prop can be any case.