### PR TITLE
feat: Add `error` event and improve error handling

### DIFF
--- a/docs/server/events-and-middleware.md
+++ b/docs/server/events-and-middleware.md
@@ -126,6 +126,24 @@ server.any().on('beforeReplay', (req, recording) => {
 });
 ```
 
+### error
+
+Fires when any error gets emitted during the request life-cycle.
+
+| Param | Type                      | Description          |
+| ----- | ------------------------- | -------------------- |
+| req   | [Request](server/request) | The request instance |
+| error | Error                     | The error            |
+
+**Example**
+
+```js
+server.any().on('error', (req, error) => {
+  console.error(error);
+  process.exit(1);
+});
+```
+
 ## Middleware
 
 Middleware can be added via the `.any()` method.

--- a/packages/@pollyjs/adapter-node-http/src/index.js
+++ b/packages/@pollyjs/adapter-node-http/src/index.js
@@ -202,6 +202,9 @@ export default class HttpAdapter extends Adapter {
     const { req, respond } = pollyRequest.requestArguments;
 
     if (error) {
+      // If an error was received then forward it over to nock so it can
+      // correctly handle it.
+      // https://github.com/nock/nock/blob/v10.0.6/lib/request_overrider.js#L394-L397
       respond(error);
 
       return;

--- a/packages/@pollyjs/adapter-node-http/src/index.js
+++ b/packages/@pollyjs/adapter-node-http/src/index.js
@@ -198,9 +198,16 @@ export default class HttpAdapter extends Adapter {
     };
   }
 
-  async respondToRequest(pollyRequest) {
-    const { statusCode, body, headers } = pollyRequest.response;
+  async respondToRequest(pollyRequest, error) {
     const { req, respond } = pollyRequest.requestArguments;
+
+    if (error) {
+      respond(error);
+
+      return;
+    }
+
+    const { statusCode, body, headers } = pollyRequest.response;
     const chunks = this.getChunksFromBody(body, headers);
     const stream = new Readable();
 

--- a/packages/@pollyjs/adapter-node-http/tests/utils/get-response-from-request.js
+++ b/packages/@pollyjs/adapter-node-http/tests/utils/get-response-from-request.js
@@ -1,8 +1,7 @@
 export default function getResponseFromRequest(req, data) {
-  return new Promise(resolve => {
-    req.on('response', res => {
-      resolve(res);
-    });
+  return new Promise((resolve, reject) => {
+    req.once('response', resolve);
+    req.once('error', reject);
 
     req.end(data);
   });

--- a/packages/@pollyjs/adapter-puppeteer/src/index.js
+++ b/packages/@pollyjs/adapter-puppeteer/src/index.js
@@ -202,6 +202,9 @@ export default class PuppeteerAdapter extends Adapter {
     const { response } = pollyRequest;
 
     if (error) {
+      // If an error was returned then we force puppeteer to abort the current
+      // request. This will emit the `requestfailed` page event and allow the end
+      // user to handle the error.
       await request.abort();
     } else {
       await request.respond({

--- a/packages/@pollyjs/adapter-xhr/src/index.js
+++ b/packages/@pollyjs/adapter-xhr/src/index.js
@@ -44,11 +44,16 @@ export default class XHRAdapter extends Adapter {
     this.xhr.restore();
   }
 
-  respondToRequest(pollyRequest) {
+  respondToRequest(pollyRequest, error) {
     const { xhr } = pollyRequest.requestArguments;
-    const { response } = pollyRequest;
 
-    xhr.respond(response.statusCode, response.headers, response.body);
+    if (error) {
+      xhr.error();
+    } else {
+      const { response } = pollyRequest;
+
+      xhr.respond(response.statusCode, response.headers, response.body);
+    }
   }
 
   async passthroughRequest(pollyRequest) {

--- a/packages/@pollyjs/adapter-xhr/src/index.js
+++ b/packages/@pollyjs/adapter-xhr/src/index.js
@@ -48,6 +48,10 @@ export default class XHRAdapter extends Adapter {
     const { xhr } = pollyRequest.requestArguments;
 
     if (error) {
+      // If an error was received then call the `error` method on the fake XHR
+      // request provided by nise which will simulate a network error on the request.
+      // The onerror handler will be called and the status will be 0.
+      // https://github.com/sinonjs/nise/blob/v1.4.10/lib/fake-xhr/index.js#L614-L621
       xhr.error();
     } else {
       const { response } = pollyRequest;

--- a/packages/@pollyjs/adapter-xhr/tests/utils/xhr-request.js
+++ b/packages/@pollyjs/adapter-xhr/tests/utils/xhr-request.js
@@ -22,7 +22,7 @@ export default function request(url, obj = {}) {
       xhr.status === 204 && xhr.responseText === '' ? null : xhr.responseText;
 
     return new Response(responseBody, {
-      status: xhr.status,
+      status: xhr.status || 500,
       statusText: xhr.statusText,
       headers: serializeResponseHeaders(xhr.getAllResponseHeaders())
     });

--- a/packages/@pollyjs/adapter/src/index.js
+++ b/packages/@pollyjs/adapter/src/index.js
@@ -300,7 +300,12 @@ export default class Adapter {
    * @param {PollyRequest} pollyRequest
    * @param {Error} error
    */
-  onRequestFailed(pollyRequest, error) {
+  async onRequestFailed(pollyRequest, error) {
+    error =
+      error || new Error('[Polly] Request failed due to an unknown error.');
+
+    await pollyRequest._emit('error', error);
+    await this.respondToRequest(pollyRequest, error);
     pollyRequest.promise.reject(error);
   }
 }

--- a/packages/@pollyjs/adapter/src/utils/stringify-request.js
+++ b/packages/@pollyjs/adapter/src/utils/stringify-request.js
@@ -1,4 +1,12 @@
 export default function stringifyRequest(req, ...args) {
+  const config = { ...req.config };
+
+  // Remove all adapter & persister config options as they can cause a circular
+  // structure to the final JSON
+  ['adapter', 'adapterOptions', 'persister', 'persisterOptions'].forEach(
+    k => delete config[k]
+  );
+
   return JSON.stringify(
     {
       url: req.url,
@@ -9,7 +17,7 @@ export default function stringifyRequest(req, ...args) {
       id: req.id,
       order: req.order,
       identifiers: req.identifiers,
-      config: req.config
+      config
     },
     ...args
   );

--- a/packages/@pollyjs/core/src/-private/logger.js
+++ b/packages/@pollyjs/core/src/-private/logger.js
@@ -13,10 +13,6 @@ export default class Logger {
     this.groupName = null;
   }
 
-  get enabled() {
-    return this.polly.config.logging;
-  }
-
   connect() {
     this._middleware = this.polly.server
       .any()
@@ -26,13 +22,6 @@ export default class Logger {
   disconnect() {
     this.groupEnd();
     this._middleware.off('response');
-  }
-
-  console(method, ...args) {
-    if (this.enabled) {
-      this.groupStart(this.polly.recordingName);
-      console[method].apply(console, args);
-    }
   }
 
   groupStart(groupName) {
@@ -67,17 +56,5 @@ export default class Logger {
         request
       );
     }
-  }
-
-  log() {
-    this.console('log', ...arguments);
-  }
-
-  warn() {
-    this.console('warn', ...arguments);
-  }
-
-  error() {
-    this.console('error', ...arguments);
   }
 }

--- a/packages/@pollyjs/core/src/server/handler.js
+++ b/packages/@pollyjs/core/src/server/handler.js
@@ -13,6 +13,7 @@ export default class Handler extends Map {
     this.set('config', {});
     this._eventEmitter = new EventEmitter({
       eventNames: [
+        'error',
         'request',
         'beforeReplay',
         'beforePersist',

--- a/tests/integration/adapter-tests.js
+++ b/tests/integration/adapter-tests.js
@@ -126,6 +126,26 @@ export default function adapterTests() {
     ]);
   });
 
+  it('should emit an error event', async function() {
+    const { server } = this.polly;
+    let error;
+
+    this.polly.configure({ recordIfMissing: false });
+
+    server.get(this.recordUrl()).on('error', (req, err) => (error = err));
+
+    try {
+      await this.fetchRecord();
+    } catch (e) {
+      /* noop */
+    }
+
+    expect(error).to.exist;
+    expect(error.message).to.match(
+      /Recording for the following request is not found/
+    );
+  });
+
   it('should handle a compressed response', async function() {
     const res = await this.relativeFetch('/compress', {
       method: 'POST',


### PR DESCRIPTION
Resolves #181 

```js
server.any().on('error', (req, error) => {
  console.error(error);
  process.exit(1);
});
```