### PR TITLE
feat(core): Filter requests matched by a route handler

### DIFF
--- a/docs/server/route-handler.md
+++ b/docs/server/route-handler.md
@@ -170,6 +170,61 @@ server.any('/session').passthrough();
 server.get('/session/1').passthrough(false);
 ```
 
+### filter
+
+Filter requests matched by the route handler with a predicate callback function.
+This can be useful when trying to match a request by a part of the url, a header,
+and/or parts of the request body.
+
+The callback will receive the [Request](server/request)
+as an argument. Return `true` to match the request, `false` otherwise.
+
+?> Multiple filters can be chained together. They must all return `true` for the route handler to match the given request.
+
+| Param    | Type       | Description                   |
+| -------- | ---------- | ----------------------------- |
+| callback | `Function` | The filter predicate function |
+
+**Example**
+
+```js
+server
+  .any()
+  .filter(req => req.hasHeader('Authentication'));
+  .on('request', req => {
+    res.setHeader('Authentication', 'test123')
+  });
+
+server
+  .get('/users/:id')
+  .filter(req => req.params.id === '1');
+  .intercept((req, res) => {
+    res.status(200).json({ email: 'user1@test.com' });
+  });
+```
+
+### configure
+
+Override configuration options for the given route. All matching middleware and route level configs are merged together and the overrides are applied to the current
+Polly instance's config.
+
+!> The following options are not supported to be overridden via the server API:
+`mode`, `adapters`, `adapterOptions`, `persister`, `persisterOptions`
+
+| Param  | Type     | Description                           |
+| ------ | -------- | ------------------------------------- |
+| config | `Object` | [Configuration](configuration) object |
+
+**Example**
+
+```js
+server.any('/session').configure({ recordFailedRequests: true });
+
+server.get('/users/:id').configure({ timing: Timing.relative(3.0) });
+
+server.get('/users/1').configure({ logging: true });
+```
+
 ### recordingName
 
 Override the recording name for the given route. This allows for grouping common
@@ -194,26 +249,4 @@ server.get('/users/:id').recordingName('User Data');
 server
   .get('/users/1')
   .recordingName(); /* Fallback to the polly instance's recording name */
-```
-
-### configure
-
-Override configuration options for the given route. All matching middleware and route level configs are merged together and the overrides are applied to the current
-Polly instance's config.
-
-!> The following options are not supported to be overridden via the server API:
-`mode`, `adapters`, `adapterOptions`, `persister`, `persisterOptions`
-
-| Param  | Type     | Description                           |
-| ------ | -------- | ------------------------------------- |
-| config | `Object` | [Configuration](configuration) object |
-
-**Example**
-
-```js
-server.any('/session').configure({ recordFailedRequests: true });
-
-server.get('/users/:id').configure({ timing: Timing.relative(3.0) });
-
-server.get('/users/1').configure({ logging: true });
 ```

--- a/packages/@pollyjs/core/src/-private/request.js
+++ b/packages/@pollyjs/core/src/-private/request.js
@@ -57,6 +57,9 @@ export default class PollyRequest extends HTTPBase {
     // Lookup the associated route for this request
     this[ROUTE] = polly.server.lookup(this.method, this.url);
 
+    // Filter all matched route handlers by this request
+    this[ROUTE].applyFiltersWithArgs(this);
+
     // Handle config overrides defined by the route
     this._configure(this[ROUTE].config());
 

--- a/packages/@pollyjs/core/src/server/handler.js
+++ b/packages/@pollyjs/core/src/server/handler.js
@@ -11,6 +11,7 @@ export default class Handler extends Map {
     super();
 
     this.set('config', {});
+    this.set('filters', new Set());
     this._eventEmitter = new EventEmitter({
       eventNames: [
         'error',
@@ -76,6 +77,17 @@ export default class Handler extends Map {
   configure(config) {
     validateRequestConfig(config);
     this.set('config', config);
+
+    return this;
+  }
+
+  filter(fn) {
+    assert(
+      `Invalid filter callback provided. Expected function, received: "${typeof fn}".`,
+      typeof fn === 'function'
+    );
+
+    this.get('filters').add(fn);
 
     return this;
   }

--- a/tests/helpers/setup-fetch-record.js
+++ b/tests/helpers/setup-fetch-record.js
@@ -18,9 +18,7 @@ setupFetchRecord.beforeEach = function(options = {}) {
 
     this.fetch = fetch;
 
-    this.relativeFetch = (url, options) => {
-      return this.fetch(`${host}${url}`, options);
-    };
+    this.relativeFetch = (url, options) => this.fetch(`${host}${url}`, options);
 
     this.recordUrl = () =>
       `${host}/api/db/${encodeURIComponent(this.polly.recordingId)}`;


### PR DESCRIPTION
## Description

Filter requests matched by the route handler with a predicate callback function.

The callback will receive the request as an argument. Return `true` to match the request, `false` otherwise.

Multiple filters can be chained together. They must all return `true` for the route handler to match the given request.

## Motivation and Context

This can be useful when trying to match a request by a part of the url (e.g. a query param), a header,
and/or parts of the request body.

## Types of Changes

<!---
  What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!---
  Go over all the following points, and put an `x` in all the boxes that apply.

  If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have added tests to cover my changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] My code follows the code style of this project.
- [x] My commits and the title of this PR follow the [Conventional Commits Specification](https://www.conventionalcommits.org).
- [x] I have read the [contributing guidelines](https://github.com/Netflix/pollyjs/blob/master/CONTRIBUTING.md).
