### PR TITLE
fix(adapter-fetch): Correctly handle key/value pairs headers

### DIFF
--- a/packages/@pollyjs/adapter-fetch/src/index.js
+++ b/packages/@pollyjs/adapter-fetch/src/index.js
@@ -26,8 +26,9 @@ export default class FetchAdapter extends Adapter {
       );
     }
 
-    this.assert('Fetch global not found.', !!(context && context.fetch));
-    this.assert('Response global not found.', !!(context && context.Response));
+    ['fetch', 'Response', 'Headers'].forEach(key =>
+      this.assert(`${key} global not found.`, !!(context && context[key]))
+    );
     this.assert(
       'Running concurrent fetch adapters is unsupported, stop any running Polly instances.',
       !context.fetch[IS_STUBBED]
@@ -39,7 +40,7 @@ export default class FetchAdapter extends Adapter {
       const pollyRequest = await this.handleRequest({
         url,
         method: options.method || 'GET',
-        headers: serializeHeaders(options.headers),
+        headers: serializeHeaders(new context.Headers(options.headers)),
         body: options.body,
         requestArguments: { options }
       });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Correctly handle key/value pairs passed as headers to a fetch request.

## Motivation and Context

<!---
  Why is this change required? What problem does it solve?

  If it fixes an open issue, please link to the issue here.
-->
Resolves #190.

A fetch request can receive headers in the following format: `[['key1', 'value1'], ['key2', 'value2']]`. To be able to support this format as well as any other formats, we create a new [Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers) instance with the original headers and serialize that. This allows us to have a normalized interface to interact with.

## Types of Changes

<!---
  What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!---
  Go over all the following points, and put an `x` in all the boxes that apply.

  If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] My code follows the code style of this project.
- [x] My commits and the title of this PR follow the [Conventional Commits Specification](https://www.conventionalcommits.org).
- [x] I have read the [contributing guidelines](https://github.com/Netflix/pollyjs/blob/master/CONTRIBUTING.md).
