### PR TITLE
fix(adapter-puppeteer): Remove other resource type matching

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,16 @@ This will bootstrap & build the packages, stand up the node test server, and
 instantiate testem. Once running, the test suite will be rerun when any changes
 are made to the src or test files.
 
+## Running Node Tests with Chrome Inspector
+
+To run the node test suite with node inspector support, run from the root directory:
+
+```bash
+yarn test:ci -l Node:debug
+```
+
+Next, attach Chrome to the running process by visiting [chrome://inspect/#devices](chrome://inspect/#devices)
+
 ## Running Docs
 
 All the documentation can be found in the root level `docs` directory. Running

--- a/docs/adapters/puppeteer.md
+++ b/docs/adapters/puppeteer.md
@@ -6,6 +6,8 @@ you to get the full power of Polly and Puppeteer.
 
 ## Installation
 
+?> **NOTE** If you're using Puppeteer 1.7 or 1.8, you'll experience issues using passthrough requests. Please upgrade to the latest version of Puppeteer or use a version prior to 1.7.
+
 _Note that you must have node (and npm) installed._
 
 ```bash

--- a/packages/@pollyjs/adapter-puppeteer/README.md
+++ b/packages/@pollyjs/adapter-puppeteer/README.md
@@ -12,6 +12,8 @@ to be used with `@pollyjs/core`.
 
 ## Installation
 
+_If you're using puppeteer 1.7 or 1.8, you'll experience issues with passthrough requests. Please upgrade to the latest version of puppeteer or use a version prior to 1.7_
+
 _Note that you must have node (and npm) installed._
 
 ```bash

--- a/packages/@pollyjs/adapter-puppeteer/src/index.js
+++ b/packages/@pollyjs/adapter-puppeteer/src/index.js
@@ -13,9 +13,7 @@ export default class PuppeteerAdapter extends Adapter {
   get defaultOptions() {
     return {
       page: null,
-
-      /* NOTE: `"other" is needed as of puppeteer 1.7.0 to capture the passthrough request */
-      requestResourceTypes: ['xhr', 'fetch', 'other']
+      requestResourceTypes: ['xhr', 'fetch']
     };
   }
 

--- a/testem.js
+++ b/testem.js
@@ -35,6 +35,9 @@ module.exports = {
   },
   middleware: [attachMiddleware],
   launchers: {
+    'Node:debug': {
+      command: 'yarn test:node --inspect-brk'
+    },
     Node: {
       command: 'yarn test:node --reporter tap',
       protocol: 'tap'


### PR DESCRIPTION
There was a change in Puppeteer 1.7 that forced us to start capturing `"other"` network requests.  

This led to proxying requests for requests like favicons.  This isn't optimal and thankfully is no longer needed as of Puppeteer >= 1.9.

fixes #149