### PR TITLE
feat(core): Improved control flow with `times` and `stopPropagation`

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -37,6 +37,7 @@
   - [Route Handler](server/route-handler.md)
   - [Request](server/request.md)
   - [Response](server/response.md)
+  - [Event](server/event.md)
 
 - Node Server
 

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -354,3 +354,8 @@ body .sidebar-toggle span:nth-child(3) {
 .lang-json .token.property {
   color: #e96900;
 }
+
+/****** COPY TO CLIPBOARD ******/
+.docsify-copy-code-button {
+  font-size: 0.7em !important;
+}

--- a/docs/server/event.md
+++ b/docs/server/event.md
@@ -1,0 +1,29 @@
+# Event
+
+## Properties
+
+### type
+
+_Type_: `String`
+
+The event type. (e.g. `request`, `response`, `beforePersist`)
+
+## Methods
+
+### stopPropagation
+
+If several event listeners are attached to the same event type, they are called in the order in which they were added. If `stopPropagation` is invoked during one such call, no remaining listeners will be called.
+
+**Example**
+
+```js
+server.get('/session/:id').on('beforeResponse', (req, res, event) => {
+  event.stopPropagation();
+  res.setHeader('X-SESSION-ID', 'ABC123');
+});
+
+server.get('/session/:id').on('beforeResponse', (req, res, event) => {
+  // This will never be reached
+  res.setHeader('X-SESSION-ID', 'XYZ456');
+});
+```

--- a/docs/server/events-and-middleware.md
+++ b/docs/server/events-and-middleware.md
@@ -42,6 +42,7 @@ Fires right before the request goes out.
 | Param | Type                      | Description          |
 | ----- | ------------------------- | -------------------- |
 | req   | [Request](server/request) | The request instance |
+| event | [Event](server/event)     | The event instance   |
 
 **Example**
 
@@ -60,6 +61,7 @@ Fires right before the response materializes and the promise resolves.
 | ----- | --------------------------- | --------------------- |
 | req   | [Request](server/request)   | The request instance  |
 | res   | [Response](server/response) | The response instance |
+| event | [Event](server/event)       | The event instance    |
 
 **Example**
 
@@ -78,6 +80,7 @@ the response materializes and the promise resolves.
 | ----- | --------------------------- | --------------------- |
 | req   | [Request](server/request)   | The request instance  |
 | res   | [Response](server/response) | The response instance |
+| event | [Event](server/event)       | The event instance    |
 
 **Example**
 
@@ -97,6 +100,7 @@ Fires before the request/response gets persisted.
 | --------- | ------------------------- | ------------------------------------ |
 | req       | [Request](server/request) | The request instance                 |
 | recording | `Object`                  | The recording that will be persisted |
+| event     | [Event](server/event)     | The event instance                   |
 
 **Example**
 
@@ -116,6 +120,7 @@ and before the recording materializes into a response.
 | --------- | ------------------------- | ----------------------- |
 | req       | [Request](server/request) | The request instance    |
 | recording | `Object`                  | The retrieved recording |
+| event     | [Event](server/event)     | The event instance      |
 
 **Example**
 
@@ -134,6 +139,7 @@ Fires when any error gets emitted during the request life-cycle.
 | ----- | ------------------------- | -------------------- |
 | req   | [Request](server/request) | The request instance |
 | error | Error                     | The error            |
+| event | [Event](server/event)     | The event instance   |
 
 **Example**
 

--- a/docs/server/request.md
+++ b/docs/server/request.md
@@ -1,5 +1,90 @@
 # Request
 
+## Properties
+
+### method
+
+_Type_: `String`
+
+The request method. (e.g. `GET`, `POST`, `DELETE`)
+
+### url
+
+_Type_: `String`
+
+The request URL.
+
+### protocol
+
+_Type_: `String`
+
+The request url protocol. (e.g. `http://`, `https:`)
+
+### hostname
+
+_Type_: `String`
+
+The request url host name. (e.g. `localhost`, `netflix.com`)
+
+### port
+
+_Type_: `String`
+
+The request url port. (e.g. `3000`)
+
+### pathname
+
+_Type_: `String`
+
+The request url path name. (e.g. `/session`, `/movies/1`)
+
+### hash
+
+_Type_: `String`
+
+The request url hash.
+
+### headers
+
+_Type_: `Object`
+_Default_: `{}`
+
+The request headers.
+
+### body
+
+_Type_: `any`
+
+The request body.
+
+### query
+
+_Type_: `Object`
+_Default_: `{}`
+
+The request url query parameters.
+
+### params
+
+_Type_: `Object`
+_Default_: `{}`
+
+The matching route's path params.
+
+**Example**
+
+```js
+server.get('/movies/:id').intercept((req, res) => {
+  console.log(req.params.id);
+});
+```
+
+### recordingName
+
+_Type_: `String`
+
+The recording the request should be recorded under.
+
 ## Methods
 
 ### getHeader
@@ -161,88 +246,3 @@ A shortcut method that calls JSON.parse on the request's body.
 ```js
 req.jsonBody();
 ```
-
-## Properties
-
-### method
-
-_Type_: `String`
-
-The request method. (e.g. `GET`, `POST`, `DELETE`)
-
-### url
-
-_Type_: `String`
-
-The request URL.
-
-### protocol
-
-_Type_: `String`
-
-The request url protocol. (e.g. `http://`, `https:`)
-
-### hostname
-
-_Type_: `String`
-
-The request url host name. (e.g. `localhost`, `netflix.com`)
-
-### port
-
-_Type_: `String`
-
-The request url port. (e.g. `3000`)
-
-### pathname
-
-_Type_: `String`
-
-The request url path name. (e.g. `/session`, `/movies/1`)
-
-### hash
-
-_Type_: `String`
-
-The request url hash.
-
-### headers
-
-_Type_: `Object`
-_Default_: `{}`
-
-The request headers.
-
-### body
-
-_Type_: `any`
-
-The request body.
-
-### query
-
-_Type_: `Object`
-_Default_: `{}`
-
-The request url query parameters.
-
-### params
-
-_Type_: `Object`
-_Default_: `{}`
-
-The matching route's path params.
-
-**Example**
-
-```js
-server.get('/movies/:id').intercept((req, res) => {
-  console.log(req.params.id);
-});
-```
-
-### recordingName
-
-_Type_: `String`
-
-The recording the request should be recorded under.

--- a/packages/@pollyjs/adapter-fetch/tests/integration/server-test.js
+++ b/packages/@pollyjs/adapter-fetch/tests/integration/server-test.js
@@ -468,7 +468,7 @@ describe('Integration | Server', function() {
           res.sendStatus(200);
         });
 
-      server.delete('/users/1').intercept((req, res) => res.sendStatus(204));
+      server.delete('/users/1').intercept((req, res) => res.status(204));
 
       // Second call should 404 since the user no longer exists
       server

--- a/packages/@pollyjs/adapter-fetch/tests/integration/server-test.js
+++ b/packages/@pollyjs/adapter-fetch/tests/integration/server-test.js
@@ -457,7 +457,7 @@ describe('Integration | Server', function() {
 
       // First call should return the user and not enter the 2nd handler
       server
-        .get('/user/1')
+        .get('/users/1')
         .times(1)
         .on('request', (req, e) => {
           e.stopPropagation();
@@ -468,25 +468,25 @@ describe('Integration | Server', function() {
           res.sendStatus(200);
         });
 
-      server.delete('/user/1').intercept((req, res) => res.sendStatus(201));
+      server.delete('/users/1').intercept((req, res) => res.sendStatus(204));
 
       // Second call should 404 since the user no longer exists
       server
-        .get('/user/1')
+        .get('/users/1')
         .times(1)
         .on('request', () => (calledAfterDelete = true))
         .intercept((req, res) => res.sendStatus(404));
 
-      expect((await fetch('/user/1')).status).to.equal(200);
+      expect((await fetch('/users/1')).status).to.equal(200);
       expect(calledBeforeDelete).to.be.true;
       expect(calledAfterDelete).to.be.false;
 
       calledBeforeDelete = false;
-      expect((await fetch('/user/1', { method: 'DELETE' })).status).to.equal(
-        201
+      expect((await fetch('/users/1', { method: 'DELETE' })).status).to.equal(
+        204
       );
 
-      expect((await fetch('/user/1')).status).to.equal(404);
+      expect((await fetch('/users/1')).status).to.equal(404);
       expect(calledBeforeDelete).to.be.false;
       expect(calledAfterDelete).to.be.true;
     });

--- a/packages/@pollyjs/adapter/src/index.js
+++ b/packages/@pollyjs/adapter/src/index.js
@@ -1,6 +1,5 @@
 import { ACTIONS, MODES, Serializers, assert } from '@pollyjs/utils';
 
-import Interceptor from './-private/interceptor';
 import isExpired from './utils/is-expired';
 import stringifyRequest from './utils/stringify-request';
 import normalizeRecordedResponse from './utils/normalize-recorded-response';
@@ -112,11 +111,9 @@ export default class Adapter {
 
   async [REQUEST_HANDLER](pollyRequest) {
     const { mode } = this.polly;
-    let interceptor;
+    const { _interceptor: interceptor } = pollyRequest;
 
     if (pollyRequest.shouldIntercept) {
-      interceptor = new Interceptor();
-
       await this.intercept(pollyRequest, interceptor);
 
       if (interceptor.shouldIntercept) {
@@ -127,7 +124,7 @@ export default class Adapter {
     if (
       mode === MODES.PASSTHROUGH ||
       pollyRequest.shouldPassthrough ||
-      (interceptor && interceptor.shouldPassthrough)
+      interceptor.shouldPassthrough
     ) {
       return this.passthrough(pollyRequest);
     }

--- a/packages/@pollyjs/core/src/-private/event-emitter.js
+++ b/packages/@pollyjs/core/src/-private/event-emitter.js
@@ -91,10 +91,21 @@ export default class EventEmitter {
         this.off(eventName, tempListener)
       );
 
+      /*
+        Remove any existing listener or tempListener that match this one.
+
+        For example, if the following would get called:
+          this.on('request', listener);
+          this.on('request', listener, { times: 1 });
+
+        We want to make sure that there is only one instance of the given
+        listener for the given event.
+      */
+      this.off(eventName, listener);
+
       // Save the original listener on the temp one so we can easily match it
       // given the original.
       tempListener.listener = listener;
-
       listener = tempListener;
     }
 

--- a/packages/@pollyjs/core/src/-private/event-emitter.js
+++ b/packages/@pollyjs/core/src/-private/event-emitter.js
@@ -4,6 +4,8 @@ import isObjectLike from 'lodash-es/isObjectLike';
 import cancelFnAfterNTimes from '../utils/cancel-fn-after-n-times';
 import { validateTimesOption } from '../utils/validators';
 
+import Event from './event';
+
 const EVENTS = Symbol();
 const EVENT_NAMES = Symbol();
 
@@ -135,7 +137,7 @@ export default class EventEmitter {
       if (typeof listener === 'function') {
         events.get(eventName).delete(listener);
 
-        // Remove any wrapped listeners that use the provided listener
+        // Remove any temp listeners that use the provided listener
         this.listeners(eventName).forEach(l => {
           if (l.listener === listener) {
             events.get(eventName).delete(l);
@@ -181,8 +183,8 @@ export default class EventEmitter {
    * `eventName`, in the order they were registered, passing the supplied
    * arguments to each.
    *
-   * Returns a promise that will resolve to `true` if the event had listeners,
-   * `false` otherwise.
+   * Returns a promise that will resolve to `false` if a listener stopped
+   * propagation, `true` otherwise.
    *
    * @async
    * @param {String} eventName - The name of the event
@@ -192,15 +194,17 @@ export default class EventEmitter {
   async emit(eventName, ...args) {
     assertEventName(eventName, this[EVENT_NAMES]);
 
-    if (this.hasListeners(eventName)) {
-      for (const listener of this.listeners(eventName)) {
-        await listener(...args);
-      }
+    const event = new Event(eventName);
 
-      return true;
+    for (const listener of this.listeners(eventName)) {
+      await listener(...args, event);
+
+      if (event.shouldStopPropagating) {
+        return false;
+      }
     }
 
-    return false;
+    return true;
   }
 
   /**
@@ -208,8 +212,8 @@ export default class EventEmitter {
    * for the event named `eventName`, in the order they were registered,
    * passing the supplied arguments to each.
    *
-   * Returns a promise that will resolve to `true` if the event had listeners,
-   * `false` otherwise.
+   * Returns a promise that will resolve to `false` if a listener stopped
+   * propagation, `true` otherwise.
    *
    * @async
    * @param {String} eventName - The name of the event
@@ -219,15 +223,17 @@ export default class EventEmitter {
   async emitParallel(eventName, ...args) {
     assertEventName(eventName, this[EVENT_NAMES]);
 
-    if (this.hasListeners(eventName)) {
-      await Promise.all(
-        this.listeners(eventName).map(listener => listener(...args))
-      );
+    const event = new Event(eventName);
 
-      return true;
+    await Promise.all(
+      this.listeners(eventName).map(listener => listener(...args, event))
+    );
+
+    if (event.shouldStopPropagating) {
+      return false;
     }
 
-    return false;
+    return true;
   }
 
   /**
@@ -237,7 +243,7 @@ export default class EventEmitter {
    *
    * Throws if a listener's return value is promise-like.
    *
-   * Returns `true` if the event had listeners, `false` otherwise.
+   * Returns`false` if a listener stopped propagation, `true` otherwise.
    *
    * @param {String} eventName - The name of the event
    * @param {any} ...args - The arguments to pass to the listeners
@@ -246,19 +252,21 @@ export default class EventEmitter {
   emitSync(eventName, ...args) {
     assertEventName(eventName, this[EVENT_NAMES]);
 
-    if (this.hasListeners(eventName)) {
-      this.listeners(eventName).forEach(listener => {
-        const returnValue = listener(...args);
+    const event = new Event(eventName);
 
-        assert(
-          `Attempted to emit a synchronous event "${eventName}" but an asynchronous listener was called.`,
-          !(isObjectLike(returnValue) && typeof returnValue.then === 'function')
-        );
-      });
+    for (const listener of this.listeners(eventName)) {
+      const returnValue = listener(...args, event);
 
-      return true;
+      assert(
+        `Attempted to emit a synchronous event "${eventName}" but an asynchronous listener was called.`,
+        !(isObjectLike(returnValue) && typeof returnValue.then === 'function')
+      );
+
+      if (event.shouldStopPropagating) {
+        return false;
+      }
     }
 
-    return false;
+    return true;
   }
 }

--- a/packages/@pollyjs/core/src/-private/event.js
+++ b/packages/@pollyjs/core/src/-private/event.js
@@ -1,0 +1,26 @@
+import { assert } from '@pollyjs/utils';
+
+const STOP_PROPAGATION = Symbol();
+
+export default class Event {
+  constructor(type, props) {
+    assert(
+      `Invalid type provided. Expected a non-empty string, received: "${typeof type}".`,
+      type && typeof type === 'string'
+    );
+
+    Object.defineProperty(this, 'type', { value: type });
+    // eslint-disable-next-line no-restricted-properties
+    Object.assign(this, props || {});
+
+    this[STOP_PROPAGATION] = false;
+  }
+
+  stopPropagation() {
+    this[STOP_PROPAGATION] = true;
+  }
+
+  get shouldStopPropagating() {
+    return this[STOP_PROPAGATION];
+  }
+}

--- a/packages/@pollyjs/core/src/-private/interceptor.js
+++ b/packages/@pollyjs/core/src/-private/interceptor.js
@@ -1,4 +1,4 @@
-import Event from '../-private/event';
+import Event from './event';
 
 const ABORT = Symbol();
 const PASSTHROUGH = Symbol();

--- a/packages/@pollyjs/core/src/-private/request.js
+++ b/packages/@pollyjs/core/src/-private/request.js
@@ -12,6 +12,7 @@ import {
   validateRecordingName,
   validateRequestConfig
 } from '../utils/validators';
+import Interceptor from '../server/interceptor';
 
 import HTTPBase from './http-base';
 import PollyResponse from './response';
@@ -53,6 +54,9 @@ export default class PollyRequest extends HTTPBase {
       This will be set by the adapter.
     */
     this.action = null;
+
+    // Interceptor instance to be passed to each of the intercept handlers
+    this._interceptor = new Interceptor();
 
     // Lookup the associated route for this request
     this[ROUTE] = polly.server.lookup(this.method, this.url);

--- a/packages/@pollyjs/core/src/-private/request.js
+++ b/packages/@pollyjs/core/src/-private/request.js
@@ -12,11 +12,11 @@ import {
   validateRecordingName,
   validateRequestConfig
 } from '../utils/validators';
-import Interceptor from '../server/interceptor';
 
 import HTTPBase from './http-base';
 import PollyResponse from './response';
 import EventEmitter from './event-emitter';
+import Interceptor from './interceptor';
 
 const { keys, freeze } = Object;
 

--- a/packages/@pollyjs/core/src/server/handler.js
+++ b/packages/@pollyjs/core/src/server/handler.js
@@ -65,11 +65,13 @@ export default class Handler extends Map {
       typeof fn === 'function'
     );
 
-    const { times } = { ...this.get('defaultOptions'), ...options };
+    options = { ...this.get('defaultOptions'), ...options };
 
-    if (times) {
-      validateTimesOption(times);
-      fn = cancelFnAfterNTimes(fn, times, () => this.delete('intercept'));
+    if ('times' in options) {
+      validateTimesOption(options.times);
+      fn = cancelFnAfterNTimes(fn, options.times, () =>
+        this.delete('intercept')
+      );
     }
 
     this.set('intercept', fn);

--- a/packages/@pollyjs/core/src/server/interceptor.js
+++ b/packages/@pollyjs/core/src/server/interceptor.js
@@ -1,3 +1,5 @@
+import Event from '../-private/event';
+
 const ABORT = Symbol();
 const PASSTHROUGH = Symbol();
 
@@ -6,8 +8,9 @@ function setDefaults(interceptor) {
   interceptor[PASSTHROUGH] = false;
 }
 
-export default class Interceptor {
+export default class Interceptor extends Event {
   constructor() {
+    super('intercept');
     setDefaults(this);
   }
 

--- a/packages/@pollyjs/core/src/server/route.js
+++ b/packages/@pollyjs/core/src/server/route.js
@@ -97,11 +97,11 @@ export default class Route {
    */
   async emit(eventName, req, ...args) {
     for (const { route, handler } of this[HANDLERS]) {
-      const listeners = handler._eventEmitter.listeners(eventName);
-
-      for (const listener of listeners) {
-        await listener(requestWithParams(req, route), ...args);
-      }
+      await handler._eventEmitter.emit(
+        eventName,
+        requestWithParams(req, route),
+        ...args
+      );
     }
   }
 

--- a/packages/@pollyjs/core/src/utils/cancel-fn-after-n-times.js
+++ b/packages/@pollyjs/core/src/utils/cancel-fn-after-n-times.js
@@ -1,0 +1,21 @@
+/**
+ * Create a function that will execute the given fn and call the cancel
+ * callback after being called n times.
+ *
+ * @export
+ * @param {Function} fn
+ * @param {Number} nTimes
+ * @param {Function} cancel
+ * @returns
+ */
+export default function cancelFnAfterNTimes(fn, nTimes, cancel) {
+  let callCount = 0;
+
+  return function(...args) {
+    if (++callCount >= nTimes) {
+      cancel();
+    }
+
+    return fn(...args);
+  };
+}

--- a/packages/@pollyjs/core/src/utils/validators.js
+++ b/packages/@pollyjs/core/src/utils/validators.js
@@ -16,7 +16,7 @@ export function validateRecordingName(name) {
 export function validateRequestConfig(config) {
   assert(
     `Invalid config provided. Expected object, received: "${typeof config}".`,
-    isObjectLike(config)
+    isObjectLike(config) && !Array.isArray(config)
   );
 
   // The following options cannot be overridden on a per request basis

--- a/packages/@pollyjs/core/src/utils/validators.js
+++ b/packages/@pollyjs/core/src/utils/validators.js
@@ -33,3 +33,15 @@ export function validateRequestConfig(config) {
     )
   );
 }
+
+export function validateTimesOption(times) {
+  assert(
+    `Invalid number provided. Expected number, received: "${typeof times}".`,
+    typeof times === 'number'
+  );
+
+  assert(
+    `Invalid number provided. The number must be greater than 0, received "${typeof times}".`,
+    times > 0
+  );
+}

--- a/packages/@pollyjs/core/tests/unit/-private/event-test.js
+++ b/packages/@pollyjs/core/tests/unit/-private/event-test.js
@@ -1,0 +1,42 @@
+import Event from '../../../src/-private/event';
+
+const EVENT_TYPE = 'foo';
+
+describe('Unit | Event', function() {
+  it('should exist', function() {
+    expect(Event).to.be.a('function');
+  });
+
+  it('should throw if no type is specified', function() {
+    expect(() => new Event()).to.throw(Error, /Invalid type provided/);
+  });
+
+  it('should have the correct defaults', function() {
+    const event = new Event(EVENT_TYPE);
+
+    expect(event.type).to.equal(EVENT_TYPE);
+    expect(event.shouldStopPropagating).to.be.false;
+  });
+
+  it('should not be able to edit the type', function() {
+    const event = new Event(EVENT_TYPE);
+
+    expect(event.type).to.equal(EVENT_TYPE);
+    expect(() => (event.type = 'bar')).to.throw(Error);
+  });
+
+  it('should be able to attach any other properties', function() {
+    const event = new Event(EVENT_TYPE, { foo: 1, bar: 2 });
+
+    expect(event.foo).to.equal(1);
+    expect(event.bar).to.equal(2);
+  });
+
+  it('.stopPropagation()', function() {
+    const event = new Event(EVENT_TYPE);
+
+    expect(event.shouldStopPropagating).to.be.false;
+    event.stopPropagation();
+    expect(event.shouldStopPropagating).to.be.true;
+  });
+});

--- a/packages/@pollyjs/core/tests/unit/-private/interceptor-test.js
+++ b/packages/@pollyjs/core/tests/unit/-private/interceptor-test.js
@@ -1,6 +1,6 @@
-import Interceptor from '../../../src/server/interceptor';
+import Interceptor from '../../../src/-private/interceptor';
 
-describe('Unit | Server | Interceptor', function() {
+describe('Unit | Interceptor', function() {
   it('should exist', function() {
     expect(Interceptor).to.be.a('function');
   });
@@ -8,9 +8,11 @@ describe('Unit | Server | Interceptor', function() {
   it('should have the correct defaults', function() {
     const interceptor = new Interceptor();
 
+    expect(interceptor.type).to.equal('intercept');
     expect(interceptor.shouldAbort).to.be.false;
     expect(interceptor.shouldPassthrough).to.be.false;
     expect(interceptor.shouldIntercept).to.be.true;
+    expect(interceptor.shouldStopPropagating).to.be.false;
   });
 
   it('should disable passthrough when calling abort and vise versa', function() {
@@ -50,5 +52,13 @@ describe('Unit | Server | Interceptor', function() {
 
     expect(interceptor.shouldPassthrough).to.be.true;
     expect(interceptor.shouldIntercept).to.be.false;
+  });
+
+  it('.stopPropagation()', function() {
+    const interceptor = new Interceptor();
+
+    expect(interceptor.shouldStopPropagating).to.be.false;
+    interceptor.stopPropagation();
+    expect(interceptor.shouldStopPropagating).to.be.true;
   });
 });

--- a/packages/@pollyjs/core/tests/unit/server/handler-test.js
+++ b/packages/@pollyjs/core/tests/unit/server/handler-test.js
@@ -59,6 +59,17 @@ describe('Unit | Server | Handler', function() {
       expect(eventEmitter.hasListeners('request')).to.be.false;
     });
 
+    it('registers a known event via .on() with .times() and override with { times }', function() {
+      const handler = new Handler();
+      const { _eventEmitter: eventEmitter } = handler;
+
+      handler.times(2).on('request', () => {}, { times: 1 });
+      expect(eventEmitter.hasListeners('request')).to.be.true;
+
+      eventEmitter.emitSync('request');
+      expect(eventEmitter.hasListeners('request')).to.be.false;
+    });
+
     it('registers a known event via .once()', function() {
       const handler = new Handler();
       const { _eventEmitter: eventEmitter } = handler;
@@ -145,6 +156,16 @@ describe('Unit | Server | Handler', function() {
       expect(handler.has('intercept')).to.be.true;
 
       handler.get('intercept')();
+      expect(handler.has('intercept')).to.be.true;
+
+      handler.get('intercept')();
+      expect(handler.has('intercept')).to.be.false;
+    });
+
+    it('registers an intercept handler with .times() and override with { times }', function() {
+      const handler = new Handler();
+
+      handler.times(2).intercept(() => {}, { times: 1 });
       expect(handler.has('intercept')).to.be.true;
 
       handler.get('intercept')();

--- a/packages/@pollyjs/core/tests/unit/server/handler-test.js
+++ b/packages/@pollyjs/core/tests/unit/server/handler-test.js
@@ -5,89 +5,318 @@ describe('Unit | Server | Handler', function() {
     expect(Handler).to.be.a('function');
   });
 
-  it('throws on registering an unknown event name', function() {
-    expect(() => new Handler().on('unknownEventName')).to.throw(
-      /Invalid event name provided/
-    );
-  });
-
-  it('throws on un-registering an unknown event name', function() {
-    expect(() => new Handler().off('unknownEventName')).to.throw(
-      /Invalid event name provided/
-    );
-  });
-
-  it('registers a known event via .on()', function() {
-    const handler = new Handler();
-    const { _eventEmitter: eventEmitter } = handler;
-
-    expect(eventEmitter.hasListeners('request')).to.be.false;
-
-    handler.on('request', () => {});
-    expect(eventEmitter.hasListeners('request')).to.be.true;
-
-    handler.on('request', () => {});
-    expect(eventEmitter.listeners('request')).to.have.lengthOf(2);
-  });
-
-  it('un-registers a known event via .off()', function() {
-    const handler = new Handler();
-    const { _eventEmitter: eventEmitter } = handler;
-    const fn = () => {};
-
-    handler.on('request', fn);
-    handler.on('request', () => {});
-    handler.on('request', () => {});
-    expect(eventEmitter.hasListeners('request')).to.be.true;
-    expect(eventEmitter.listeners('request')).to.have.lengthOf(3);
-
-    handler.off('request', fn);
-    expect(eventEmitter.hasListeners('request')).to.be.true;
-    expect(eventEmitter.listeners('request')).to.have.lengthOf(2);
-    expect(eventEmitter.listeners('request').includes(fn)).to.be.false;
-
-    handler.off('request');
-    expect(eventEmitter.hasListeners('request')).to.be.false;
-    expect(eventEmitter.listeners('request')).to.have.lengthOf(0);
-  });
-
-  it('registers an intercept handler', function() {
-    const handler = new Handler();
-
-    handler.intercept(() => {});
-    expect(handler.has('intercept')).to.be.true;
-  });
-
-  it('throws when passing a non-function to intercept', function() {
-    const handler = new Handler();
-
-    [null, undefined, {}, [], ''].forEach(value => {
-      expect(() => handler.intercept(value)).to.throw(
-        /Invalid intercept handler provided/
+  describe('Events', function() {
+    it('throws on registering an unknown event name', function() {
+      expect(() => new Handler().on('unknownEventName')).to.throw(
+        /Invalid event name provided/
       );
+    });
+
+    it('throws on un-registering an unknown event name', function() {
+      expect(() => new Handler().off('unknownEventName')).to.throw(
+        /Invalid event name provided/
+      );
+    });
+
+    it('registers a known event via .on()', function() {
+      const handler = new Handler();
+      const { _eventEmitter: eventEmitter } = handler;
+
+      expect(eventEmitter.hasListeners('request')).to.be.false;
+
+      handler.on('request', () => {});
+      expect(eventEmitter.hasListeners('request')).to.be.true;
+
+      handler.on('request', () => {});
+      expect(eventEmitter.listeners('request')).to.have.lengthOf(2);
+    });
+
+    it('registers a known event via .on() with { times }', function() {
+      const handler = new Handler();
+      const { _eventEmitter: eventEmitter } = handler;
+
+      handler.on('request', () => {}, { times: 2 });
+      expect(eventEmitter.hasListeners('request')).to.be.true;
+
+      eventEmitter.emitSync('request');
+      expect(eventEmitter.hasListeners('request')).to.be.true;
+
+      eventEmitter.emitSync('request');
+      expect(eventEmitter.hasListeners('request')).to.be.false;
+    });
+
+    it('registers a known event via .on() with .times()', function() {
+      const handler = new Handler();
+      const { _eventEmitter: eventEmitter } = handler;
+
+      handler.times(2).on('request', () => {});
+      expect(eventEmitter.hasListeners('request')).to.be.true;
+
+      eventEmitter.emitSync('request');
+      expect(eventEmitter.hasListeners('request')).to.be.true;
+
+      eventEmitter.emitSync('request');
+      expect(eventEmitter.hasListeners('request')).to.be.false;
+    });
+
+    it('registers a known event via .once()', function() {
+      const handler = new Handler();
+      const { _eventEmitter: eventEmitter } = handler;
+
+      expect(eventEmitter.hasListeners('request')).to.be.false;
+
+      handler.once('request', () => {});
+      expect(eventEmitter.hasListeners('request')).to.be.true;
+
+      handler.once('request', () => {});
+      expect(eventEmitter.listeners('request')).to.have.lengthOf(2);
+
+      eventEmitter.emitSync('request');
+      expect(eventEmitter.hasListeners('request')).to.be.false;
+    });
+
+    it('un-registers a known event via .off()', function() {
+      const handler = new Handler();
+      const { _eventEmitter: eventEmitter } = handler;
+      const fn = () => {};
+
+      handler.on('request', fn);
+      handler.on('request', () => {});
+      handler.on('request', () => {});
+      expect(eventEmitter.hasListeners('request')).to.be.true;
+      expect(eventEmitter.listeners('request')).to.have.lengthOf(3);
+
+      handler.off('request', fn);
+      expect(eventEmitter.hasListeners('request')).to.be.true;
+      expect(eventEmitter.listeners('request')).to.have.lengthOf(2);
+      expect(eventEmitter.listeners('request').includes(fn)).to.be.false;
+
+      handler.off('request');
+      expect(eventEmitter.hasListeners('request')).to.be.false;
+      expect(eventEmitter.listeners('request')).to.have.lengthOf(0);
     });
   });
 
-  it('removes the intercept handler on passthrough', function() {
-    const handler = new Handler();
+  describe('.intercept()', function() {
+    it('registers an intercept handler', function() {
+      const handler = new Handler();
 
-    handler.intercept(() => {});
-    expect(handler.has('intercept')).to.be.true;
+      handler.intercept(() => {});
+      expect(handler.has('intercept')).to.be.true;
+    });
 
-    handler.passthrough();
-    expect(handler.get('passthrough')).to.be.true;
-    expect(handler.has('intercept')).to.be.false;
+    it('throws when passing a non-function to intercept', function() {
+      const handler = new Handler();
+
+      [null, undefined, {}, [], ''].forEach(value => {
+        expect(() => handler.intercept(value)).to.throw(
+          /Invalid intercept handler provided/
+        );
+      });
+    });
+
+    it('throws when passing an invalid times option', function() {
+      const handler = new Handler();
+
+      ['1', -1, 0].forEach(times => {
+        expect(() => handler.intercept(() => {}, { times })).to.throw(
+          /Invalid number provided/
+        );
+      });
+    });
+
+    it('registers an intercept handler with { times }', function() {
+      const handler = new Handler();
+
+      handler.intercept(() => {}, { times: 2 });
+      expect(handler.has('intercept')).to.be.true;
+
+      handler.get('intercept')();
+      expect(handler.has('intercept')).to.be.true;
+
+      handler.get('intercept')();
+      expect(handler.has('intercept')).to.be.false;
+    });
+
+    it('registers an intercept handler with .times()', function() {
+      const handler = new Handler();
+
+      handler.times(2).intercept(() => {});
+      expect(handler.has('intercept')).to.be.true;
+
+      handler.get('intercept')();
+      expect(handler.has('intercept')).to.be.true;
+
+      handler.get('intercept')();
+      expect(handler.has('intercept')).to.be.false;
+    });
   });
 
-  it('disables passthrough on intercept', function() {
-    const handler = new Handler();
+  describe('.passthrough()', function() {
+    it('should work', function() {
+      const handler = new Handler();
 
-    handler.passthrough();
-    expect(handler.get('passthrough')).to.be.true;
-    expect(handler.has('intercept')).to.be.false;
+      expect(handler.has('passthrough')).to.be.false;
 
-    handler.intercept(() => {});
-    expect(handler.has('intercept')).to.be.true;
-    expect(handler.get('passthrough')).to.be.false;
+      handler.passthrough();
+      expect(handler.get('passthrough')).to.be.true;
+
+      handler.passthrough(false);
+      expect(handler.get('passthrough')).to.be.false;
+    });
+
+    it('removes the intercept handler on passthrough', function() {
+      const handler = new Handler();
+
+      handler.intercept(() => {});
+      expect(handler.has('intercept')).to.be.true;
+
+      handler.passthrough();
+      expect(handler.get('passthrough')).to.be.true;
+      expect(handler.has('intercept')).to.be.false;
+    });
+
+    it('disables passthrough on intercept', function() {
+      const handler = new Handler();
+
+      handler.passthrough();
+      expect(handler.get('passthrough')).to.be.true;
+      expect(handler.has('intercept')).to.be.false;
+
+      handler.intercept(() => {});
+      expect(handler.has('intercept')).to.be.true;
+      expect(handler.get('passthrough')).to.be.false;
+    });
+  });
+
+  describe('.recordingName()', function() {
+    it('should work', function() {
+      const handler = new Handler();
+
+      expect(handler.has('recordingName')).to.be.false;
+
+      handler.recordingName('Test');
+      expect(handler.get('recordingName')).to.equal('Test');
+
+      handler.recordingName();
+      expect(handler.has('recordingName')).to.be.true;
+      expect(handler.get('recordingName')).to.be.undefined;
+    });
+
+    it('should allow setting a falsy recordingName', function() {
+      const handler = new Handler();
+
+      expect(handler.has('recordingName')).to.be.false;
+
+      [false, undefined, null].forEach(value => {
+        handler.recordingName(value);
+        expect(handler.has('recordingName')).to.be.true;
+        expect(handler.get('recordingName')).to.equal(value);
+      });
+    });
+
+    it('throws when passing an invalid truthy recording name', function() {
+      const handler = new Handler();
+
+      [1, {}, [], true].forEach(value => {
+        expect(() => handler.recordingName(value)).to.throw(
+          /Invalid recording name provided/
+        );
+      });
+    });
+  });
+
+  describe('.configure()', function() {
+    it('should work', function() {
+      const handler = new Handler();
+
+      expect(handler.get('config')).to.deep.equal({});
+
+      handler.configure({ logging: true });
+      expect(handler.get('config')).to.deep.equal({ logging: true });
+
+      handler.configure({ recordIfMissing: false });
+      expect(handler.get('config')).to.deep.equal({ recordIfMissing: false });
+
+      handler.configure({});
+      expect(handler.get('config')).to.deep.equal({});
+    });
+
+    it('throws when passing an invalid config', function() {
+      const handler = new Handler();
+
+      [false, true, null, undefined, 1, []].forEach(config => {
+        expect(() => handler.configure(config)).to.throw(
+          /Invalid config provided/
+        );
+      });
+
+      [
+        'mode',
+        'adapters',
+        'adapterOptions',
+        'persister',
+        'persisterOptions'
+      ].forEach(key => {
+        expect(() => handler.configure({ [key]: key })).to.throw(
+          /Invalid configuration option provided/
+        );
+      });
+    });
+  });
+
+  describe('.filter()', function() {
+    it('should work', function() {
+      const handler = new Handler();
+      const filters = handler.get('filters');
+      const fn = () => {};
+
+      expect(filters.size).to.equal(0);
+
+      handler.filter(fn);
+      expect(filters.size).to.equal(1);
+
+      handler.filter(fn);
+      expect(filters.size).to.equal(1);
+
+      handler.filter(() => {});
+      expect(filters.size).to.equal(2);
+    });
+
+    it('throws when passing an invalid fn', function() {
+      const handler = new Handler();
+
+      [false, true, null, undefined, 1, [], {}, ''].forEach(fn => {
+        expect(() => handler.filter(fn)).to.throw(
+          /Invalid filter callback provided/
+        );
+      });
+    });
+  });
+
+  describe('.times()', function() {
+    it('should work', function() {
+      const handler = new Handler();
+      const defaultOptions = handler.get('defaultOptions');
+
+      expect(defaultOptions).to.deep.equal({});
+
+      handler.times(1);
+      expect(defaultOptions).to.deep.equal({ times: 1 });
+
+      handler.times(2);
+      expect(defaultOptions).to.deep.equal({ times: 2 });
+
+      handler.times();
+      expect(defaultOptions).to.deep.equal({});
+    });
+
+    it('throws when passing an invalid times option', function() {
+      const handler = new Handler();
+
+      ['1', -1, 0].forEach(times => {
+        expect(() => handler.times(times)).to.throw(/Invalid number provided/);
+      });
+    });
   });
 });

--- a/packages/@pollyjs/core/tests/unit/server/interceptor-test.js
+++ b/packages/@pollyjs/core/tests/unit/server/interceptor-test.js
@@ -1,6 +1,6 @@
-import Interceptor from '../../../src/-private/interceptor';
+import Interceptor from '../../../src/server/interceptor';
 
-describe('Unit | Private | Interceptor', function() {
+describe('Unit | Server | Interceptor', function() {
   it('should exist', function() {
     expect(Interceptor).to.be.a('function');
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR includes 2 features that when used together, can be really powerful. 

The first is the ability to remove an intercept or event handler after a specified amount of times it has been called via the handler's `.times(n)` API or by providing it as an option to `.on(eventName, fn, { times })` or `.intercept(fn, { times })`.

The second, is the ability to prevent calling the next handlers registered for the events or intercept. This can be done via `interceptor.stopPropagation()` or via a new Event instance passed to every event handler by calling `event.stopPropagation()`.

## Motivation and Context

Lets take an example where we might want to intercept a user being removed. The first call to GET the user should return the user's info but after we delete the user, it should return a 404.

```js
// First call should return the user and not enter the 2nd handler
server
  .get('/users/1')
  .times(1) // Remove this interceptor after it gets called once
  .intercept((req, res, interceptor) => {
    // Do not continue to the next intercept handler which handles the 404 case
    interceptor.stopPropagation(); 
    res.sendStatus(200);
  });

server.delete('/users/1').intercept((req, res) => res.sendStatus(204));

// Second call should 404 since the user no longer exists
server
  .get('/users/1')
  .intercept((req, res) => res.sendStatus(404));
```

Then when the following requests get made, we are able to simulate the correct responses:

```js
await fetch('/users/1'); // --> 200
await fetch('/users/1', { method: 'DELETE' }); // --> 204
await fetch('/users/1');  // --> 404
```

## Types of Changes

<!---
  What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!---
  Go over all the following points, and put an `x` in all the boxes that apply.

  If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have added tests to cover my changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] My code follows the code style of this project.
- [x] My commits and the title of this PR follow the [Conventional Commits Specification](https://www.conventionalcommits.org).
- [x] I have read the [contributing guidelines](https://github.com/Netflix/pollyjs/blob/master/CONTRIBUTING.md).
