### PR TITLE
 feat: Implement expiryStrategy

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,8 +54,9 @@ polly.configure({
 });
 ```
 
-## recordIfExpired - _deprecated! use expiryStrategy_
+## recordIfExpired
 
+_deprecated! use [expiryStrategy](#expiryStrategy)_
 _Type_: `Boolean`
 _Default_: `false`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,7 +54,7 @@ polly.configure({
 });
 ```
 
-## recordIfExpired
+## recordIfExpired - _deprecated! use expiryStrategy_
 
 _Type_: `Boolean`
 _Default_: `false`
@@ -93,7 +93,8 @@ _Type_: `String`
 _Default_: `null`
 
 After how long the recorded request will be considered expired from the time
-it was persisted.
+it was persisted. A recorded request is considered expired if the recording's
+`startedDateTime` plus the current `expiresIn` duration is in the past.
 
 **Example**
 
@@ -104,6 +105,25 @@ polly.configure({
 
 polly.configure({
   expiresIn: '5 min 10 seconds 100 milliseconds' // expires in 5 minutes, 10 seconds, and 100 milliseconds
+});
+```
+
+## expiryStrategy
+
+_Type_: `String`
+_Default_: `warn`
+
+The strategy for what should occur when Polly tries to use an expired recording in `replay` mode. Can be one of the following:
+
+- `warn`: Log a console warning about the expired recording.
+- `error`: Throw an error.
+- `record`: Re-record by making a new network request.
+
+**Example**
+
+```js
+polly.configure({
+  expiryStrategy: 'error'
 });
 ```
 

--- a/packages/@pollyjs/adapter/src/index.js
+++ b/packages/@pollyjs/adapter/src/index.js
@@ -166,6 +166,13 @@ export default class Adapter {
   async record(pollyRequest) {
     pollyRequest.action = ACTIONS.RECORD;
 
+    if ('navigator' in global && !navigator.onLine) {
+      console.warn(
+        '[Polly] Recording will fail because the browser is offline.\n' +
+          `${stringifyRequest(pollyRequest)}`
+      );
+    }
+
     return this.onRecord(pollyRequest);
   }
 

--- a/packages/@pollyjs/adapter/src/index.js
+++ b/packages/@pollyjs/adapter/src/index.js
@@ -167,17 +167,13 @@ export default class Adapter {
         switch (config.expiryStrategy) {
           // exit into the record flow if expiryStrategy is "record".
           case EXPIRY_STRATEGIES.RECORD:
-            console.log('using record strategy');
-
             return this.record(pollyRequest);
           // throw an error and exit if expiryStrategy is "error".
           case EXPIRY_STRATEGIES.ERROR:
-            console.log('using error strategy');
             this.assert(message);
             break;
           // log a warning and continue if expiryStrategy is "warn".
           case EXPIRY_STRATEGIES.WARN:
-            console.log('using warn strategy');
             console.warn(`[Polly] ${message}`);
             break;
           // throw an error if we encounter an unsupported expiryStrategy.

--- a/packages/@pollyjs/adapter/src/index.js
+++ b/packages/@pollyjs/adapter/src/index.js
@@ -1,4 +1,10 @@
-import { ACTIONS, MODES, Serializers, assert } from '@pollyjs/utils';
+import {
+  ACTIONS,
+  MODES,
+  EXPIRY_STRATEGIES,
+  Serializers,
+  assert
+} from '@pollyjs/utils';
 
 import isExpired from './utils/is-expired';
 import stringifyRequest from './utils/stringify-request';
@@ -50,36 +56,6 @@ export default class Adapter {
       this.onDisconnect();
       this.isConnected = false;
     }
-  }
-
-  shouldReRecord(pollyRequest, recordingEntry) {
-    const { config } = pollyRequest;
-
-    if (isExpired(recordingEntry.startedDateTime, config.expiresIn)) {
-      if (!config.recordIfExpired) {
-        console.warn(
-          '[Polly] Recording for the following request has expired but `recordIfExpired` is `false`.\n' +
-            `${recordingEntry.request.method} ${recordingEntry.request.url}\n`,
-          recordingEntry
-        );
-
-        return false;
-      }
-
-      if ('navigator' in global && !navigator.onLine) {
-        console.warn(
-          '[Polly] Recording for the following request has expired but the browser is offline.\n' +
-            `${recordingEntry.request.method} ${recordingEntry.request.url}\n`,
-          recordingEntry
-        );
-
-        return false;
-      }
-
-      return true;
-    }
-
-    return false;
   }
 
   timeout(pollyRequest, { time }) {
@@ -183,8 +159,23 @@ export default class Adapter {
     if (recordingEntry) {
       await pollyRequest._emit('beforeReplay', recordingEntry);
 
-      if (this.shouldReRecord(pollyRequest, recordingEntry)) {
-        return this.record(pollyRequest);
+      if (isExpired(recordingEntry.startedDateTime, config.expiresIn)) {
+        const message =
+          'Recording for the following request has expired.\n' +
+          `${recordingEntry.request.method} ${recordingEntry.request.url}\n`;
+
+        if (config.expiryStrategy === EXPIRY_STRATEGIES.ERROR) {
+          assert(message);
+        } else if (config.expiryStrategy === EXPIRY_STRATEGIES.WARN) {
+          console.warn(`[Polly] ${message}`, recordingEntry);
+        } else if (config.expiryStrategy === EXPIRY_STRATEGIES.RECORD) {
+          return this.record(pollyRequest);
+        } else {
+          // TODO should there be a generic validator available for all config options?
+          assert(
+            `Invalid config option passed for "expiryStrategy": "${config.expiryStrategy}"`
+          );
+        }
       }
 
       await this.timeout(pollyRequest, recordingEntry);

--- a/packages/@pollyjs/core/src/defaults/config.js
+++ b/packages/@pollyjs/core/src/defaults/config.js
@@ -1,4 +1,4 @@
-import { MODES } from '@pollyjs/utils';
+import { MODES, EXPIRY_STRATEGIES } from '@pollyjs/utils';
 
 import Timing from '../utils/timing';
 
@@ -19,7 +19,7 @@ export default {
   recordFailedRequests: false,
 
   expiresIn: null,
-  expiryStrategy: 'replay',
+  expiryStrategy: EXPIRY_STRATEGIES.WARN,
   timing: Timing.fixed(0),
 
   matchRequestsBy: {

--- a/packages/@pollyjs/core/src/defaults/config.js
+++ b/packages/@pollyjs/core/src/defaults/config.js
@@ -16,10 +16,10 @@ export default {
   logging: false,
 
   recordIfMissing: true,
-  recordIfExpired: false,
   recordFailedRequests: false,
 
   expiresIn: null,
+  expiryStrategy: 'replay',
   timing: Timing.fixed(0),
 
   matchRequestsBy: {

--- a/packages/@pollyjs/core/src/utils/merge-configs.js
+++ b/packages/@pollyjs/core/src/utils/merge-configs.js
@@ -1,25 +1,21 @@
 import mergeWith from 'lodash-es/mergeWith';
-import { assert, EXPIRY_STRATEGIES } from '@pollyjs/utils';
+import { EXPIRY_STRATEGIES } from '@pollyjs/utils';
 
 function deprecateRecordIfExpired(mergedConfig) {
-  // throw if you used both recordIfExpired and expiryStrategy
-  assert(
-    'recordIfExpired is deprecated and cannot be used with expiryStrategy',
-    mergedConfig.hasOwnProperty('recordIfExpired') &&
-      mergedConfig.hasOwnProperty('expiryStrategy')
-  );
+  if (mergedConfig.hasOwnProperty('recordIfExpired')) {
+    console.warn(
+      '[Polly] config option "recordIfExpired" is deprecated. Please use "expiryStrategy".'
+    );
 
-  // return if you only used expiryStrategy
-  if (mergedConfig.hasOwnProperty('expiryStrategy')) {
-    return mergedConfig;
-  }
+    if (mergedConfig.recordIfExpired) {
+      // replace recordIfExpired: true with expiryStrategy: record
+      mergedConfig.expiryStrategy = EXPIRY_STRATEGIES.RECORD;
+    } else {
+      // replace recordIfExpired: false with expiryStrategy: warn
+      mergedConfig.expiryStrategy = EXPIRY_STRATEGIES.WARN;
+    }
 
-  if (mergedConfig.recordIfExpired) {
-    // replace recordIfExpired: true with expiryStrategy: record
-    mergedConfig.expiryStrategy = EXPIRY_STRATEGIES.RECORD;
-  } else {
-    // replace recordIfExpired: false with expiryStrategy: warn
-    mergedConfig.expiryStrategy = EXPIRY_STRATEGIES.WARN;
+    delete mergedConfig.recordIfExpired;
   }
 
   return mergedConfig;

--- a/packages/@pollyjs/utils/src/constants/expiry-strategies.js
+++ b/packages/@pollyjs/utils/src/constants/expiry-strategies.js
@@ -1,0 +1,5 @@
+export default {
+  RECORD: 'record',
+  WARN: 'warn',
+  ERROR: 'error'
+};

--- a/packages/@pollyjs/utils/src/index.js
+++ b/packages/@pollyjs/utils/src/index.js
@@ -2,6 +2,7 @@ export { default as MODES } from './constants/modes';
 export { default as ACTIONS } from './constants/actions';
 export { default as HTTP_METHODS } from './constants/http-methods';
 export { default as HTTP_STATUS_CODES } from './constants/http-status-codes';
+export { default as EXPIRY_STRATEGIES } from './constants/expiry-strategies';
 
 export { default as assert } from './utils/assert';
 export { default as timeout } from './utils/timeout';


### PR DESCRIPTION
## Description

Per discussion in #226, this implements an `expiryStrategy` config option and deprecates `recordIfExpired` (without a breaking change) . It supports the existing flows and adds the new `error` state, which throws when the strategy is set to `error` and an expired recording is about to be used in `replay` mode.

We are still implementing tests, but would love input on the approach.

## Motivation and Context

See #226 for detailed info.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have added tests to cover my changes. - *Tests in progress, the `it` blocks are included for now, let us know if they would be in line with the overall testing strategy for the repo.*
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] My code follows the code style of this project.
- [x] My commits and the title of this PR follow the [Conventional Commits Specification](https://www.conventionalcommits.org).
- [x] I have read the [contributing guidelines](https://github.com/Netflix/pollyjs/blob/master/CONTRIBUTING.md).
