### PR TITLE
feat: PollyError and improved adapter error handling

### DIFF
--- a/packages/@pollyjs/adapter-fetch/src/index.js
+++ b/packages/@pollyjs/adapter-fetch/src/index.js
@@ -104,22 +104,23 @@ export default class FetchAdapter extends Adapter {
       return;
     }
 
-    const { absoluteUrl, response } = pollyRequest;
-    const { statusCode } = response;
+    const { absoluteUrl, response: pollyResponse } = pollyRequest;
+    const { statusCode } = pollyResponse;
     const responseBody =
-      statusCode === 204 && response.body === '' ? null : response.body;
-
-    const fetchResponse = new Response(responseBody, {
+      statusCode === 204 && pollyResponse.body === ''
+        ? null
+        : pollyResponse.body;
+    const response = new Response(responseBody, {
       status: statusCode,
-      headers: response.headers
+      headers: pollyResponse.headers
     });
 
     /*
       Response does not allow `url` to be set manually (either via the
       constructor or assignment) so force the url property via `defineProperty`.
     */
-    defineProperty(fetchResponse, 'url', { value: absoluteUrl });
+    defineProperty(response, 'url', { value: absoluteUrl });
 
-    respond({ response: fetchResponse });
+    respond({ response });
   }
 }

--- a/packages/@pollyjs/adapter-fetch/src/index.js
+++ b/packages/@pollyjs/adapter-fetch/src/index.js
@@ -95,6 +95,8 @@ export default class FetchAdapter extends Adapter {
 
     if (error) {
       respond({ error });
+
+      return;
     }
 
     const { absoluteUrl, response } = pollyRequest;

--- a/packages/@pollyjs/adapter-fetch/tests/integration/server-test.js
+++ b/packages/@pollyjs/adapter-fetch/tests/integration/server-test.js
@@ -1,4 +1,5 @@
 import { setupMocha as setupPolly } from '@pollyjs/core';
+import { PollyError } from '@pollyjs/utils';
 
 import pollyConfig from '../utils/polly-config';
 
@@ -80,7 +81,7 @@ describe('Integration | Server', function() {
         'persisterOptions'
       ].forEach(key =>
         expect(() => server.any().configure({ [key]: 'foo' })).to.throw(
-          Error,
+          PollyError,
           /Invalid configuration option/
         )
       );
@@ -197,7 +198,7 @@ describe('Integration | Server', function() {
       const { server } = this.polly;
 
       expect(() => server.any().filter()).to.throw(
-        Error,
+        PollyError,
         /Invalid filter callback provided/
       );
     });

--- a/packages/@pollyjs/adapter-node-http/src/index.js
+++ b/packages/@pollyjs/adapter-node-http/src/index.js
@@ -75,18 +75,13 @@ export default class HttpAdapter extends Adapter {
           body = JSON.stringify(body);
         }
 
-        adapter
-          .handleRequest({
-            url,
-            method,
-            headers,
-            body,
-            requestArguments: { req, body, respond, parsedArguments }
-          })
-          .catch(e => {
-            // This allows the consumer to handle the error gracefully
-            req.emit('error', e);
-          });
+        adapter.handleRequest({
+          url,
+          method,
+          headers,
+          body,
+          requestArguments: { req, body, respond, parsedArguments }
+        });
       });
     });
 
@@ -206,6 +201,9 @@ export default class HttpAdapter extends Adapter {
       // correctly handle it.
       // https://github.com/nock/nock/blob/v10.0.6/lib/request_overrider.js#L394-L397
       respond(error);
+
+      // This allows the consumer to handle the error gracefully
+      req.emit('error', error);
 
       return;
     }

--- a/packages/@pollyjs/adapter-puppeteer/tests/unit/adapter-test.js
+++ b/packages/@pollyjs/adapter-puppeteer/tests/unit/adapter-test.js
@@ -1,4 +1,5 @@
 import { setupMocha as setupPolly } from '@pollyjs/core';
+import { PollyError } from '@pollyjs/utils';
 
 import PuppeteerAdapter from '../../src';
 
@@ -10,6 +11,6 @@ describe('Unit | Puppeteer Adapter', function() {
       this.polly.configure({
         adapters: [PuppeteerAdapter]
       })
-    ).to.throw(Error, /A puppeteer page instance is required/);
+    ).to.throw(PollyError, /A puppeteer page instance is required/);
   });
 });

--- a/packages/@pollyjs/core/src/-private/event-emitter.js
+++ b/packages/@pollyjs/core/src/-private/event-emitter.js
@@ -36,10 +36,12 @@ export default class EventEmitter {
    * @param {Object} options
    * @param {String[]} options.eventNames - Supported events
    */
-  constructor({ eventNames = [] }) {
+  constructor(options = {}) {
+    const { eventNames } = options;
+
     assert(
       'An array of supported events must be provided via the `eventNames` option.',
-      eventNames && eventNames.length > 0
+      Array.isArray(eventNames) && eventNames.length > 0
     );
 
     this[EVENTS] = new Map();

--- a/packages/@pollyjs/core/src/-private/logger.js
+++ b/packages/@pollyjs/core/src/-private/logger.js
@@ -65,19 +65,17 @@ export default class Logger {
   }
 
   logError(request, error) {
-    if (request.config.logging) {
-      this.groupStart(request.recordingName);
+    this.groupStart(request.recordingName);
 
-      console.groupCollapsed(`Errored ➞ ${request.method} ${request.url}`);
-      console.error(error);
-      console.log('Request:', request);
+    console.group(`Errored ➞ ${request.method} ${request.url}`);
+    console.error(error);
+    console.log('Request:', request);
 
-      if (request.didRespond) {
-        console.log('Response:', request.response);
-      }
-
-      console.log('Identifiers:', request.identifiers);
-      console.groupEnd();
+    if (request.didRespond) {
+      console.log('Response:', request.response);
     }
+
+    console.log('Identifiers:', request.identifiers);
+    console.groupEnd();
   }
 }

--- a/packages/@pollyjs/core/src/test-helpers/lib.js
+++ b/packages/@pollyjs/core/src/test-helpers/lib.js
@@ -1,4 +1,7 @@
+import { PollyError } from '@pollyjs/utils';
+
 import Polly from '../polly';
+
 const { defineProperty } = Object;
 
 export function beforeEach(context, recordingName, defaults) {
@@ -17,8 +20,8 @@ export async function afterEach(context, framework) {
     enumerable: true,
     configurable: true,
     get() {
-      throw new Error(
-        `[Polly] You are trying to access an instance of Polly that is no longer available.\n` +
+      throw new PollyError(
+        `You are trying to access an instance of Polly that is no longer available.\n` +
           `See: https://netflix.github.io/pollyjs/#/test-frameworks/${framework}?id=test-hook-ordering`
       );
     }

--- a/packages/@pollyjs/core/tests/unit/-private/container-test.js
+++ b/packages/@pollyjs/core/tests/unit/-private/container-test.js
@@ -1,3 +1,5 @@
+import { PollyError } from '@pollyjs/utils';
+
 import Container from '../../../src/-private/container';
 
 let container;
@@ -40,15 +42,15 @@ describe('Unit | Container', function() {
       }
 
       expect(() => container.register()).to.throw(
-        Error,
+        PollyError,
         /invalid factory provided/
       );
       expect(() => container.register(NoName)).to.throw(
-        Error,
+        PollyError,
         /Invalid registration name provided/
       );
       expect(() => container.register(NoType)).to.throw(
-        Error,
+        PollyError,
         /Invalid registration type provided/
       );
     });

--- a/packages/@pollyjs/core/tests/unit/-private/event-emitter-test.js
+++ b/packages/@pollyjs/core/tests/unit/-private/event-emitter-test.js
@@ -1,4 +1,4 @@
-import { timeout } from '@pollyjs/utils';
+import { PollyError, timeout } from '@pollyjs/utils';
 
 import EventEmitter from '../../../src/-private/event-emitter';
 
@@ -6,18 +6,18 @@ let emitter;
 
 function assertEventName(methodName) {
   expect(() => emitter[methodName]()).to.throw(
-    Error,
+    PollyError,
     /Invalid event name provided. Expected string/
   );
   expect(() => emitter[methodName]('invalid')).to.throw(
-    Error,
+    PollyError,
     /Possible events: a, b/
   );
 }
 
 function assertListener(methodName) {
   expect(() => emitter[methodName]('a')).to.throw(
-    Error,
+    PollyError,
     /Invalid listener provided/
   );
 }
@@ -29,9 +29,9 @@ describe('Unit | EventEmitter', function() {
   });
 
   it('should throw without eventNames', function() {
-    expect(() => new EventEmitter()).to.throw(Error);
+    expect(() => new EventEmitter()).to.throw(PollyError);
     expect(() => new EventEmitter({ eventNames: [] })).to.throw(
-      Error,
+      PollyError,
       /supported events must be provided/
     );
   });
@@ -82,12 +82,12 @@ describe('Unit | EventEmitter', function() {
       const listener = () => listenerCalled++;
 
       expect(() => emitter.on('a', listener, { times: '1' })).to.throw(
-        Error,
+        PollyError,
         /Invalid number provided/
       );
 
       expect(() => emitter.on('a', listener, { times: -1 })).to.throw(
-        Error,
+        PollyError,
         /The number must be greater than 0/
       );
 
@@ -244,7 +244,7 @@ describe('Unit | EventEmitter', function() {
     it('.emitSync()', async function() {
       emitter.once('a', () => Promise.resolve());
       expect(() => emitter.emitSync('a')).to.throw(
-        Error,
+        PollyError,
         /Attempted to emit a synchronous event/
       );
 

--- a/packages/@pollyjs/core/tests/unit/-private/event-test.js
+++ b/packages/@pollyjs/core/tests/unit/-private/event-test.js
@@ -1,3 +1,5 @@
+import { PollyError } from '@pollyjs/utils';
+
 import Event from '../../../src/-private/event';
 
 const EVENT_TYPE = 'foo';
@@ -8,7 +10,7 @@ describe('Unit | Event', function() {
   });
 
   it('should throw if no type is specified', function() {
-    expect(() => new Event()).to.throw(Error, /Invalid type provided/);
+    expect(() => new Event()).to.throw(PollyError, /Invalid type provided/);
   });
 
   it('should have the correct defaults', function() {

--- a/packages/@pollyjs/core/tests/unit/-private/response-test.js
+++ b/packages/@pollyjs/core/tests/unit/-private/response-test.js
@@ -1,3 +1,5 @@
+import { PollyError } from '@pollyjs/utils';
+
 import PollyResponse from '../../../src/-private/response';
 
 let response;
@@ -26,7 +28,7 @@ describe('Unit | Response', function() {
 
       [null, '', 0, 99, 600, 999].forEach(statusCode => {
         expect(() => response.status(statusCode)).to.throw(
-          Error,
+          PollyError,
           /Invalid status code/
         );
       });

--- a/packages/@pollyjs/core/tests/unit/polly-test.js
+++ b/packages/@pollyjs/core/tests/unit/polly-test.js
@@ -1,6 +1,6 @@
 import Adapter from '@pollyjs/adapter';
 import Persister from '@pollyjs/persister';
-import { MODES } from '@pollyjs/utils';
+import { MODES, PollyError } from '@pollyjs/utils';
 
 import defaults from '../../src/defaults/config';
 import Polly from '../../src/polly';
@@ -29,7 +29,7 @@ describe('Unit | Polly', function() {
       const polly = new Polly('test');
 
       expect(() => (polly.recordingName = value)).to.throw(
-        Error,
+        PollyError,
         /Invalid recording name provided/
       );
 
@@ -73,7 +73,7 @@ describe('Unit | Polly', function() {
     const polly = new Polly('squawk');
 
     expect(() => (polly.mode = 'INVALID')).to.throw(
-      Error,
+      PollyError,
       /Invalid mode provided/
     );
 
@@ -134,8 +134,8 @@ describe('Unit | Polly', function() {
     it('should not be configurable once requests are handled', async function() {
       this.polly._requests.push({});
       expect(() => this.polly.configure()).to.throw(
-        Error,
-        '[Polly] Cannot call `configure` once requests have been handled.'
+        PollyError,
+        'Cannot call `configure` once requests have been handled.'
       );
     });
 
@@ -143,8 +143,8 @@ describe('Unit | Polly', function() {
       await this.polly.stop();
 
       expect(() => this.polly.configure()).to.throw(
-        Error,
-        '[Polly] Cannot call `configure` on an instance of Polly that is not running.'
+        PollyError,
+        'Cannot call `configure` on an instance of Polly that is not running.'
       );
     });
 
@@ -450,7 +450,7 @@ describe('Unit | Polly', function() {
         Polly.once('create', () => {});
         Polly.once('create', () => Promise.resolve());
 
-        expect(() => new Polly('Test')).to.throw(Error);
+        expect(() => new Polly('Test')).to.throw(PollyError);
       });
 
       it('create - configuration order should be preserved', async function() {

--- a/packages/@pollyjs/utils/src/index.js
+++ b/packages/@pollyjs/utils/src/index.js
@@ -8,6 +8,7 @@ export { default as timeout } from './utils/timeout';
 export { default as timestamp } from './utils/timestamp';
 export { default as buildUrl } from './utils/build-url';
 
+export { default as PollyError } from './utils/polly-error';
 export { default as Serializers } from './utils/serializers';
 
 export { default as URL } from './utils/url';

--- a/packages/@pollyjs/utils/src/utils/assert.js
+++ b/packages/@pollyjs/utils/src/utils/assert.js
@@ -1,5 +1,7 @@
+import PollyError from './polly-error';
+
 export default function(msg, condition) {
   if (!condition) {
-    throw new Error(`[Polly] ${msg}`);
+    throw new PollyError(msg);
   }
 }

--- a/packages/@pollyjs/utils/src/utils/polly-error.js
+++ b/packages/@pollyjs/utils/src/utils/polly-error.js
@@ -1,0 +1,12 @@
+export default class PollyError extends Error {
+  constructor(message, ...args) {
+    super(`[Polly] ${message}`, ...args);
+
+    // Maintains proper stack trace for where our error was thrown (only available on V8)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, PollyError);
+    }
+
+    this.name = 'PollyError';
+  }
+}

--- a/packages/@pollyjs/utils/tests/unit/utils/assert-test.js
+++ b/packages/@pollyjs/utils/tests/unit/utils/assert-test.js
@@ -1,4 +1,5 @@
 import assert from '../../../src/utils/assert';
+import PollyError from '../../../src/utils/polly-error';
 
 describe('Unit | Utils | assert', function() {
   it('should exist', function() {
@@ -6,7 +7,11 @@ describe('Unit | Utils | assert', function() {
   });
 
   it('should throw with a false condition', function() {
-    expect(() => assert('Test', false)).to.throw(Error, '[Polly] Test');
+    expect(() => assert('Test', false)).to.throw(PollyError, /Test/);
+  });
+
+  it('should throw without a condition', function() {
+    expect(() => assert('Test')).to.throw(PollyError, /Test/);
   });
 
   it('should not throw with a true condition', function() {

--- a/packages/@pollyjs/utils/tests/unit/utils/polly-error-test.js
+++ b/packages/@pollyjs/utils/tests/unit/utils/polly-error-test.js
@@ -1,0 +1,19 @@
+import PollyError from '../../../src/utils/polly-error';
+
+describe('Unit | Utils | PollyError', function() {
+  it('should exist', function() {
+    expect(PollyError).to.be.a('function');
+  });
+
+  it('should set the name to PollyError', function() {
+    const error = new PollyError('Test');
+
+    expect(error.name).to.equal('PollyError');
+  });
+
+  it('should prefix the message with [Polly]', function() {
+    const error = new PollyError('Test');
+
+    expect(error.message).to.equal('[Polly] Test');
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Replace all error usage with a custom `PollyError` class
- Always log errors and default the console group to be open so they are visible
- Improve the base adapter's error handling to give adapters more control
- Refactor some error handling logic to support the above point in some adapters.

## Types of Changes

<!---
  What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!---
  Go over all the following points, and put an `x` in all the boxes that apply.

  If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] My code follows the code style of this project.
- [x] My commits and the title of this PR follow the [Conventional Commits Specification](https://www.conventionalcommits.org).
- [x] I have read the [contributing guidelines](https://github.com/Netflix/pollyjs/blob/master/CONTRIBUTING.md).
