### PR TITLE
fix: Default to empty string if userAgent is empty

### DIFF
--- a/packages/@pollyjs/persister/src/har/log.js
+++ b/packages/@pollyjs/persister/src/har/log.js
@@ -3,7 +3,7 @@ import Bowser from 'bowser';
 
 const bowser =
   'navigator' in global
-    ? Bowser.getParser(global.navigator.userAgent).getBrowser()
+    ? Bowser.getParser(global.navigator.userAgent || '').getBrowser()
     : null;
 const browser =
   bowser && bowser.name && bowser.version


### PR DESCRIPTION
## Description
Bowser throws when userAgent is not a string. Default userAgent to empty string when it's empty fixes the issue.

## Motivation and Context
This is to prevent non-browser app (React Native) from crashing.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] My code follows the code style of this project.
- [x] My commits and the title of this PR follow the [Conventional Commits Specification](https://www.conventionalcommits.org).
- [x] I have read the [contributing guidelines](https://github.com/Netflix/pollyjs/blob/master/CONTRIBUTING.md).
