### PR TITLE
fix: Bowser.getParser empty string UserAgent error

### DIFF
--- a/packages/@pollyjs/persister/src/har/log.js
+++ b/packages/@pollyjs/persister/src/har/log.js
@@ -2,8 +2,8 @@ import uniqWith from 'lodash-es/uniqWith';
 import Bowser from 'bowser';
 
 const bowser =
-  'navigator' in global
-    ? Bowser.getParser(global.navigator.userAgent || '').getBrowser()
+  global.navigator && global.navigator.userAgent
+    ? Bowser.getParser(global.navigator.userAgent).getBrowser()
     : null;
 const browser =
   bowser && bowser.name && bowser.version


### PR DESCRIPTION
## Description

It turns out that Bower doesn't allow any forms of empty UserAgent in getParser function https://github.com/lancedikson/bowser/blob/41bbfc1600fc38d3ea5f49dcfba5bc28cd7357aa/src/parser.js#L24.

## Motivation and Context

Making it works for React Native app.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] My code follows the code style of this project.
- [x] My commits and the title of this PR follow the [Conventional Commits Specification](https://www.conventionalcommits.org).
- [x] I have read the [contributing guidelines](https://github.com/Netflix/pollyjs/blob/master/CONTRIBUTING.md).
