### PR TITLE
fix(adapter-puppeteer): Make page.evaluate synchronous (#266)

### DIFF
--- a/packages/@pollyjs/adapter-puppeteer/src/index.js
+++ b/packages/@pollyjs/adapter-puppeteer/src/index.js
@@ -163,24 +163,28 @@ export default class PuppeteerAdapter extends Adapter {
     parsedUrl.query[PASSTHROUGH_REQ_ID_QP] = requestId;
 
     try {
-      const response = await new Promise((resolve, reject) => {
+      const response = await new Promise(async (resolve, reject) => {
         this[PASSTHROUGH_PROMISES].set(requestId, { resolve, reject });
 
         // This gets evaluated within the browser's context, meaning that
         // this fetch call executes from within the browser.
-        page.evaluate(
-          new Function(
-            'url',
-            'method',
-            'headers',
-            'body',
-            'return fetch(url, { method, headers, body });'
-          ),
-          parsedUrl.toString(),
-          method,
-          headers,
-          body
-        );
+        try {
+          await page.evaluate(
+            new Function(
+              'url',
+              'method',
+              'headers',
+              'body',
+              'return fetch(url, { method, headers, body });'
+            ),
+            parsedUrl.toString(),
+            method,
+            headers,
+            body
+          );
+        } catch (error) {
+          reject(error);
+        }
       });
 
       return {


### PR DESCRIPTION
## Description

Puppeteer's `page.evaluate` can throw errors async which are currently not being handled.

## Motivation and Context

I'm running puppeteer tests within Jest and anytime chrome throws an error during `page.evaluate` it crashes my tests. This can happen when a request is still pending and `page.goto` is used.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] My code follows the code style of this project.
- [x] My commits and the title of this PR follow the [Conventional Commits Specification](https://www.conventionalcommits.org).
- [x] I have read the [contributing guidelines](https://github.com/Netflix/pollyjs/blob/master/CONTRIBUTING.md).
