### PR TITLE
fix(node-server): Stable stringify recording data when saving to the fs

### DIFF
--- a/packages/@pollyjs/node-server/package.json
+++ b/packages/@pollyjs/node-server/package.json
@@ -41,8 +41,9 @@
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
     "express": "^4.17.1",
-    "fs-extra": "^8.0.1",
+    "fs-extra": "^8.1.0",
     "http-graceful-shutdown": "^2.3.1",
+    "json-stable-stringify": "^1.0.1",
     "morgan": "^1.9.1",
     "nocache": "^2.1.0"
   },

--- a/packages/@pollyjs/node-server/src/api.js
+++ b/packages/@pollyjs/node-server/src/api.js
@@ -1,5 +1,6 @@
 import path from 'path';
 
+import stringify from 'json-stable-stringify';
 import fs from 'fs-extra';
 import { assert } from '@pollyjs/utils';
 
@@ -26,9 +27,10 @@ export default class API {
   }
 
   saveRecording(recording, data) {
-    fs.outputJsonSync(this.filenameFor(recording), data, {
-      spaces: 2
-    });
+    fs.outputFileSync(
+      this.filenameFor(recording),
+      stringify(data, { space: 2 })
+    );
 
     return this.respond(201);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6933,12 +6933,12 @@ fs-extra@^7.0.0, fs-extra@^7.0.1:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.0.1.tgz#90294081f978b1f182f347a440a209154344285b"
-  integrity sha512-W+XLrggcDzlle47X/XnS7FXrXu9sDo+Ze9zpndeBxdgv88FHLm1HtmkhEwavruS6koanBjp098rUpHs65EmG7A==
+fs-extra@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
+  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
   dependencies:
-    graceful-fs "^4.1.2"
+    graceful-fs "^4.2.0"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
@@ -7418,6 +7418,11 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
+
+graceful-fs@^4.2.0:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
+  integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
 
 "graceful-readlink@>= 1.0.0":
   version "1.0.1"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

The core issue was that `fs.outputJsonSync` was doing a JSON.stringify which ends up generating a non-deterministic json object. To fix this, I've converted to using  `s.outputFileSync` and passing it a stable-stringified json string.

## Motivation and Context

<!---
  Why is this change required? What problem does it solve?

  If it fixes an open issue, please link to the issue here.
-->

Resolves #269.

## Types of Changes

<!---
  What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!---
  Go over all the following points, and put an `x` in all the boxes that apply.

  If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] My code follows the code style of this project.
- [x] My commits and the title of this PR follow the [Conventional Commits Specification](https://www.conventionalcommits.org).
- [x] I have read the [contributing guidelines](https://github.com/Netflix/pollyjs/blob/master/CONTRIBUTING.md).
