### PR TITLE
fix(ember): BREAKING load polly config for ember by its own module

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -231,7 +231,7 @@ for more details.
 polly.configure({
   persisterOptions: {
     rest: {
-      apiNamespace: '/pollyjs'
+      apiNamespace: '/polly'
     }
   }
 });

--- a/docs/frameworks/ember-cli.md
+++ b/docs/frameworks/ember-cli.md
@@ -17,25 +17,20 @@ ember install @pollyjs/ember
 ## Configuration
 
 Addon and [server API configuration](node-server/overview#api-configuration) can be
-be specified in `ember-cli-build.js`. The default configuration options are shown
-below.
+be specified in `<ember app root>/config/polly.js`. The default configuration options are shown below.
 
 ```js
-module.exports = function(defaults) {
-  const app = new EmberApp(defaults, {
-    pollyjs: {
-      // Addon Configuration Options
-      enabled: EmberApp.env() !== 'production',
+module.exports = function(env) {
+  return {
+    // Addon Configuration Options
+    enabled: env !== 'production',
 
-      // Server Configuration Options
-      server: {
-        apiNamespace: 'polly',
-        recordingsDir: 'recordings'
-      }
+    // Server Configuration Options
+    server: {
+      apiNamespace: '/polly',
+      recordingsDir: 'recordings'
     }
-  });
-
-  return app.toTree();
+  };
 };
 ```
 

--- a/docs/node-server/overview.md
+++ b/docs/node-server/overview.md
@@ -32,7 +32,7 @@ const { Server } = require('@pollyjs/node-server');
 const server = new Server({
   quiet: true,
   port: 4000,
-  apiNamespace: '/pollyjs'
+  apiNamespace: '/polly'
 });
 
 // Add custom business logic to the express server
@@ -115,11 +115,11 @@ instance via the [Persister Options](persisters/rest#apinamespace)
 
 ```js
 new Server({
-  apiNamespace: 'polly_js'
+  apiNamespace: '/polly'
 });
 
 registerExpressAPI(app, {
-  apiNamespace: 'polly_js'
+  apiNamespace: '/polly'
 });
 ```
 

--- a/docs/persisters/rest.md
+++ b/docs/persisters/rest.md
@@ -77,7 +77,7 @@ option.
 polly.configure({
   persisterOptions: {
     rest: {
-      apiNamespace: '/pollyjs'
+      apiNamespace: '/polly'
     }
   }
 });

--- a/packages/@pollyjs/ember/.npmignore
+++ b/packages/@pollyjs/ember/.npmignore
@@ -4,6 +4,7 @@
 
 # dependencies
 /bower_components/
+/node_modules/
 
 # misc
 /.bowerrc
@@ -16,12 +17,12 @@
 /.travis.yml
 /.watchmanconfig
 /bower.json
-/config/ember-try.js
 /ember-cli-build.js
 /testem.js
 /tests/
 /yarn.lock
 .gitkeep
+/config/
 
 # ember-try
 /.node_modules.ember-try/

--- a/packages/@pollyjs/ember/README.md
+++ b/packages/@pollyjs/ember/README.md
@@ -37,7 +37,7 @@ module.exports = function(defaults) {
 
       // Server Configuration Options
       server: {
-        apiNamespace: 'polly',
+        apiNamespace: '/polly',
         recordingsDir: 'recordings',
         recordingSizeLimit: '50mb'
       }

--- a/packages/@pollyjs/ember/blueprints/@pollyjs/ember/files/config/polly.js
+++ b/packages/@pollyjs/ember/blueprints/@pollyjs/ember/files/config/polly.js
@@ -1,0 +1,13 @@
+/* eslint-env node */
+
+'use strict';
+
+module.exports = function(env) {
+  return {
+    enabled: env !== 'production',
+    server: {
+      apiNamespace: '/polly',
+      recordingsDir: 'recordings'
+    }
+  };
+};

--- a/packages/@pollyjs/ember/blueprints/@pollyjs/ember/index.js
+++ b/packages/@pollyjs/ember/blueprints/@pollyjs/ember/index.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = {
+  description: 'Setup @pollyjs/ember',
+  normalizeEntityName() {}
+};

--- a/packages/@pollyjs/ember/config/polly.js
+++ b/packages/@pollyjs/ember/config/polly.js
@@ -1,0 +1,14 @@
+/* eslint-env node */
+
+'use strict';
+
+module.exports = function(env) {
+  // See: https://netflix.github.io/pollyjs/#/frameworks/ember-cli?id=configuration
+  return {
+    enabled: env !== 'production',
+    server: {
+      apiNamespace: '/polly',
+      recordingsDir: 'recordings'
+    }
+  };
+};

--- a/packages/@pollyjs/ember/package.json
+++ b/packages/@pollyjs/ember/package.json
@@ -43,7 +43,8 @@
     "@pollyjs/persister-local-storage": "^2.6.3",
     "@pollyjs/persister-rest": "^2.6.3",
     "ember-auto-import": "^1.2.15",
-    "ember-cli-babel": "^6.16.0"
+    "ember-cli-babel": "^6.16.0",
+    "minimist": "^1.2.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.6.3",

--- a/packages/@pollyjs/node-server/README.md
+++ b/packages/@pollyjs/node-server/README.md
@@ -44,7 +44,7 @@ const { Server } = require('@pollyjs/node-server');
 const server = new Server({
   quiet: true,
   port: 4000,
-  apiNamespace: '/pollyjs'
+  apiNamespace: '/polly'
 });
 
 // Add custom business logic to the express server

--- a/packages/@pollyjs/node-server/src/config.js
+++ b/packages/@pollyjs/node-server/src/config.js
@@ -3,5 +3,5 @@ export default {
   quiet: false,
   recordingSizeLimit: '50mb',
   recordingsDir: 'recordings',
-  apiNamespace: 'polly'
+  apiNamespace: '/polly'
 };


### PR DESCRIPTION
Currently we rely on `included()` to be called and read all config options from `app.options` derived from `ember-cli-build.js` at the time the app is built.  This strategy is no longer reliable since you can run tests against previously built assets which means `included` is never called nor is `app.options` available since the app isn't being built.

Instead, I introduced `config/polly.js` and rely upon my own function to determine what the env is (see: https://github.com/ember-cli/ember-cli/issues/8922 as to why I had to go with that approach).

This is a breaking change for @pollyjs/ember so we'll need to release a new major for the addon.

Resolves #276