### PR TITLE
fix(core): Disconnect from all adapters when `pause` is called

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - export PATH=$HOME/.yarn/bin:$PATH
 
 install:
-  - yarn install --frozen-lockfile --non-interactive
+  - yarn install --no-lockfile --non-interactive
 
 script:
   - commitlint-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - export PATH=$HOME/.yarn/bin:$PATH
 
 install:
-  - yarn install --no-lockfile --non-interactive
+  - yarn install --frozen-lockfile --non-interactive
 
 script:
   - commitlint-travis

--- a/docs/api.md
+++ b/docs/api.md
@@ -181,30 +181,36 @@ polly.replay();
 
 ### pause
 
-Puts polly in a paused mode. All requests going forward will pass through
-and will not be recorded or replayed. The previous mode will be saved and can
-be restored by calling [play](api#play)
+Disconnects the polly instance from all connected adapters. This ensures that
+no requests will be handled by the polly instance until calling [play](api#play)
+or manually connecting to a new adapter via [connectTo](api#connectTo). The
+previously connected adapters will be saved and can be restored by
+calling [play](api#play).
 
 **Example**
 
 ```js
-// polly.mode === 'replay'
+await fetch('/api/not-a-secret');
 polly.pause();
-// polly.mode === 'passthrough'
+// This and all subsequent requests will no longer be handled by polly
+await fetch('/api/secret');
 ```
 
 ### play
 
-Restores the mode to the one before [pause](api#pause) was called.
+Reconnects to the adapters that were disconnected when [pause](api#pause)
+was called.
 
 **Example**
 
 ```js
-// polly.mode === 'replay'
+await fetch('/api/not-a-secret');
 polly.pause();
-// polly.mode === 'passthrough'
+// This and all subsequent requests will no longer be handled by polly
+await fetch('/api/secret');
 polly.play();
-// polly.mode === 'replay'
+// This and all subsequent requests will again be handled by polly
+await fetch('/api/not-a-secret');
 ```
 
 ### stop

--- a/docs/api.md
+++ b/docs/api.md
@@ -179,6 +179,17 @@ played back from a saved recording.
 polly.replay();
 ```
 
+### passthrough
+
+Puts polly in pass-through mode. All requests going forward will pass-through
+directly to the server without being recorded or replayed.
+
+**Example**
+
+```js
+polly.passthrough();
+```
+
 ### pause
 
 Disconnects the polly instance from all connected adapters. This ensures that
@@ -186,6 +197,9 @@ no requests will be handled by the polly instance until calling [play](api#play)
 or manually connecting to a new adapter via [connectTo](api#connectTo). The
 previously connected adapters will be saved and can be restored by
 calling [play](api#play).
+
+?> If using the [Puppeteer Adapter](adapters/puppeteer), you'll need to also
+disable request interception via `await page.setRequestInterception(false)`.
 
 **Example**
 
@@ -200,6 +214,9 @@ await fetch('/api/secret');
 
 Reconnects to the adapters that were disconnected when [pause](api#pause)
 was called.
+
+?> If using the [Puppeteer Adapter](adapters/puppeteer), you'll need to also
+enable request interception via `await page.setRequestInterception(true)`.
 
 **Example**
 

--- a/packages/@pollyjs/adapter-fetch/tests/integration/adapter-test.js
+++ b/packages/@pollyjs/adapter-fetch/tests/integration/adapter-test.js
@@ -2,6 +2,7 @@ import { Polly, setupMocha as setupPolly } from '@pollyjs/core';
 import { URL } from '@pollyjs/utils';
 import setupFetchRecord from '@pollyjs-tests/helpers/setup-fetch-record';
 import adapterTests from '@pollyjs-tests/integration/adapter-tests';
+import adapterPollyTests from '@pollyjs-tests/integration/adapter-polly-tests';
 import adapterBrowserTests from '@pollyjs-tests/integration/adapter-browser-tests';
 import adapterIdentifierTests from '@pollyjs-tests/integration/adapter-identifier-tests';
 
@@ -19,6 +20,7 @@ describe('Integration | Fetch Adapter', function() {
   setupPolly.afterEach();
 
   adapterTests();
+  adapterPollyTests();
   adapterBrowserTests();
   adapterIdentifierTests();
 

--- a/packages/@pollyjs/adapter-puppeteer/tests/integration/adapter-test.js
+++ b/packages/@pollyjs/adapter-puppeteer/tests/integration/adapter-test.js
@@ -34,7 +34,7 @@ describe('Integration | Puppeteer Adapter', function() {
     }
   });
 
-  setupFetchRecord({ host: HOST });
+  setupFetchRecord.beforeEach({ host: HOST });
 
   beforeEach(function() {
     // Override this.fetch here since it needs access to the current context
@@ -54,6 +54,14 @@ describe('Integration | Puppeteer Adapter', function() {
       }
     });
   });
+
+  afterEach(async function() {
+    // Turn off request interception before setupFetchRecord's afterEach so it
+    // can correctly do it's thing
+    await this.page.setRequestInterception(false);
+  });
+
+  setupFetchRecord.afterEach();
 
   afterEach(async function() {
     await this.page.close();

--- a/packages/@pollyjs/core/src/polly.js
+++ b/packages/@pollyjs/core/src/polly.js
@@ -202,6 +202,14 @@ export default class Polly {
    * @public
    * @memberof Polly
    */
+  passthrough() {
+    this.mode = MODES.PASSTHROUGH;
+  }
+
+  /**
+   * @public
+   * @memberof Polly
+   */
   pause() {
     this[PAUSED_ADAPTERS] = [...this.adapters.keys()];
     this.disconnect();

--- a/packages/@pollyjs/core/src/polly.js
+++ b/packages/@pollyjs/core/src/polly.js
@@ -14,7 +14,7 @@ import { validateRecordingName } from './utils/validators';
 
 const RECORDING_NAME = Symbol();
 const RECORDING_ID = Symbol();
-const PAUSED_MODE = Symbol();
+const PAUSED_ADAPTERS = Symbol();
 
 const FACTORY_REGISTRATION = new WeakMap();
 const EVENT_EMITTER = new EventEmitter({
@@ -203,8 +203,8 @@ export default class Polly {
    * @memberof Polly
    */
   pause() {
-    this[PAUSED_MODE] = this.mode;
-    this.mode = MODES.PASSTHROUGH;
+    this[PAUSED_ADAPTERS] = [...this.adapters.keys()];
+    this.disconnect();
   }
 
   /**
@@ -212,9 +212,9 @@ export default class Polly {
    * @memberof Polly
    */
   play() {
-    if (this[PAUSED_MODE]) {
-      this.mode = this[PAUSED_MODE];
-      delete this[PAUSED_MODE];
+    if (this[PAUSED_ADAPTERS]) {
+      this[PAUSED_ADAPTERS].forEach(adapterName => this.connectTo(adapterName));
+      delete this[PAUSED_ADAPTERS];
     }
   }
 

--- a/packages/@pollyjs/core/tests/unit/polly-test.js
+++ b/packages/@pollyjs/core/tests/unit/polly-test.js
@@ -239,6 +239,21 @@ describe('Unit | Polly', function() {
   describe('API', function() {
     setupPolly();
 
+    class MockAdapterA extends Adapter {
+      static get name() {
+        return 'adapter-a';
+      }
+
+      onConnect() {}
+      onDisconnect() {}
+    }
+
+    class MockAdapterB extends MockAdapterA {
+      static get name() {
+        return 'adapter-b';
+      }
+    }
+
     it('.record()', async function() {
       this.polly.mode = MODES.REPLAY;
 
@@ -256,23 +271,35 @@ describe('Unit | Polly', function() {
     });
 
     it('.pause()', async function() {
-      this.polly.mode = MODES.RECORD;
+      this.polly.configure({ adapters: [MockAdapterA, MockAdapterB] });
 
-      expect(this.polly.mode).to.equal(MODES.RECORD);
+      expect([...this.polly.adapters.keys()]).to.deep.equal([
+        'adapter-a',
+        'adapter-b'
+      ]);
       this.polly.pause();
-      expect(this.polly.mode).to.equal(MODES.PASSTHROUGH);
+      expect([...this.polly.adapters.keys()]).to.deep.equal([]);
     });
 
     it('.play()', async function() {
-      this.polly.mode = MODES.RECORD;
+      this.polly.configure({ adapters: [MockAdapterA, MockAdapterB] });
 
-      expect(this.polly.mode).to.equal(MODES.RECORD);
+      expect([...this.polly.adapters.keys()]).to.deep.equal([
+        'adapter-a',
+        'adapter-b'
+      ]);
       this.polly.play();
-      expect(this.polly.mode).to.equal(MODES.RECORD);
+      expect([...this.polly.adapters.keys()]).to.deep.equal([
+        'adapter-a',
+        'adapter-b'
+      ]);
       this.polly.pause();
-      expect(this.polly.mode).to.equal(MODES.PASSTHROUGH);
+      expect([...this.polly.adapters.keys()]).to.deep.equal([]);
       this.polly.play();
-      expect(this.polly.mode).to.equal(MODES.RECORD);
+      expect([...this.polly.adapters.keys()]).to.deep.equal([
+        'adapter-a',
+        'adapter-b'
+      ]);
     });
 
     it('.stop()', async function() {

--- a/packages/@pollyjs/core/tests/unit/polly-test.js
+++ b/packages/@pollyjs/core/tests/unit/polly-test.js
@@ -270,6 +270,14 @@ describe('Unit | Polly', function() {
       expect(this.polly.mode).to.equal(MODES.REPLAY);
     });
 
+    it('.passthrough()', async function() {
+      this.polly.mode = MODES.RECORD;
+
+      expect(this.polly.mode).to.equal(MODES.RECORD);
+      this.polly.passthrough();
+      expect(this.polly.mode).to.equal(MODES.PASSTHROUGH);
+    });
+
     it('.pause()', async function() {
       this.polly.configure({ adapters: [MockAdapterA, MockAdapterB] });
 

--- a/tests/integration/adapter-polly-tests.js
+++ b/tests/integration/adapter-polly-tests.js
@@ -1,0 +1,22 @@
+export default function pollyTests() {
+  it('should not handle any requests when paused', async function() {
+    const { server } = this.polly;
+    const requests = [];
+
+    server.any().on('request', req => requests.push(req));
+
+    await this.fetchRecord();
+    await this.fetchRecord();
+
+    this.polly.pause();
+    await this.fetchRecord();
+    await this.fetchRecord();
+
+    this.polly.play();
+    await this.fetchRecord();
+
+    expect(requests.length).to.equal(3);
+    expect(this.polly._requests.length).to.equal(3);
+    expect(requests.map(r => r.order)).to.deep.equal([0, 1, 2]);
+  });
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Calling `polly.pause()` will now disconnect from all connected adapters instead of setting the mode to passthrough. Calling `polly.play()` will reconnect to the disconnected adapters before pause was called.

## Motivation and Context

Resolves #285.

## Types of Changes

<!---
  What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!---
  Go over all the following points, and put an `x` in all the boxes that apply.

  If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have added tests to cover my changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] My code follows the code style of this project.
- [x] My commits and the title of this PR follow the [Conventional Commits Specification](https://www.conventionalcommits.org).
- [x] I have read the [contributing guidelines](https://github.com/Netflix/pollyjs/blob/master/CONTRIBUTING.md).
