### PR TITLE
fix(adapter): Clone the recording entry before mutating it

### DIFF
--- a/packages/@pollyjs/adapter/src/index.js
+++ b/packages/@pollyjs/adapter/src/index.js
@@ -153,7 +153,7 @@ export default class Adapter {
 
   async replay(pollyRequest) {
     const { config } = pollyRequest;
-    let recordingEntry = await this.persister.findEntry(pollyRequest);
+    const recordingEntry = await this.persister.findEntry(pollyRequest);
 
     if (recordingEntry) {
       /*
@@ -163,11 +163,11 @@ export default class Adapter {
         Note: Using JSON.parse/stringify instead of lodash/cloneDeep since
               the recording entry is stored as json.
       */
-      recordingEntry = JSON.parse(JSON.stringify(recordingEntry));
+      const clonedRecordingEntry = JSON.parse(JSON.stringify(recordingEntry));
 
-      await pollyRequest._emit('beforeReplay', recordingEntry);
+      await pollyRequest._emit('beforeReplay', clonedRecordingEntry);
 
-      if (isExpired(recordingEntry.startedDateTime, config.expiresIn)) {
+      if (isExpired(clonedRecordingEntry.startedDateTime, config.expiresIn)) {
         const message =
           'Recording for the following request has expired.\n' +
           `${stringifyRequest(pollyRequest, null, 2)}`;
@@ -193,13 +193,13 @@ export default class Adapter {
         }
       }
 
-      await this.timeout(pollyRequest, recordingEntry);
+      await this.timeout(pollyRequest, clonedRecordingEntry);
       pollyRequest.action = ACTIONS.REPLAY;
 
       return this.onReplay(
         pollyRequest,
-        normalizeRecordedResponse(recordingEntry.response),
-        recordingEntry
+        normalizeRecordedResponse(clonedRecordingEntry.response),
+        clonedRecordingEntry
       );
     }
 

--- a/packages/@pollyjs/adapter/src/index.js
+++ b/packages/@pollyjs/adapter/src/index.js
@@ -153,9 +153,18 @@ export default class Adapter {
 
   async replay(pollyRequest) {
     const { config } = pollyRequest;
-    const recordingEntry = await this.persister.findEntry(pollyRequest);
+    let recordingEntry = await this.persister.findEntry(pollyRequest);
 
     if (recordingEntry) {
+      /*
+        Clone the recording entry so any changes will not actually persist to
+        the stored recording.
+
+        Note: Using JSON.parse/stringify instead of lodash/cloneDeep since
+              the recording entry is stored as json.
+      */
+      recordingEntry = JSON.parse(JSON.stringify(recordingEntry));
+
       await pollyRequest._emit('beforeReplay', recordingEntry);
 
       if (isExpired(recordingEntry.startedDateTime, config.expiresIn)) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Clone the recording entry before the `beforeReplay` event so any changes will not actually persist to the stored recording.

## Motivation and Context

<!---
  Why is this change required? What problem does it solve?

  If it fixes an open issue, please link to the issue here.
-->

Resolves #265.

## Types of Changes

<!---
  What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!---
  Go over all the following points, and put an `x` in all the boxes that apply.

  If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] My code follows the code style of this project.
- [x] My commits and the title of this PR follow the [Conventional Commits Specification](https://www.conventionalcommits.org).
- [x] I have read the [contributing guidelines](https://github.com/Netflix/pollyjs/blob/master/CONTRIBUTING.md).
