### PR TITLE
feat(core): Remove deprecated `recordIfExpired` option

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,23 +54,6 @@ polly.configure({
 });
 ```
 
-## recordIfExpired
-
-_deprecated! use [expiryStrategy](#expiryStrategy)_
-_Type_: `Boolean`
-_Default_: `false`
-
-If a request's recording has expired, pass-through to the server and
-record a new response.
-
-**Example**
-
-```js
-polly.configure({
-  recordIfExpired: true
-});
-```
-
 ## recordFailedRequests
 
 _Type_: `Boolean`

--- a/packages/@pollyjs/core/src/utils/merge-configs.js
+++ b/packages/@pollyjs/core/src/utils/merge-configs.js
@@ -1,25 +1,4 @@
 import mergeWith from 'lodash-es/mergeWith';
-import { EXPIRY_STRATEGIES } from '@pollyjs/utils';
-
-function deprecateRecordIfExpired(mergedConfig) {
-  if (mergedConfig.hasOwnProperty('recordIfExpired')) {
-    console.warn(
-      '[Polly] config option "recordIfExpired" is deprecated. Please use "expiryStrategy".'
-    );
-
-    if (mergedConfig.recordIfExpired) {
-      // replace recordIfExpired: true with expiryStrategy: record
-      mergedConfig.expiryStrategy = EXPIRY_STRATEGIES.RECORD;
-    } else {
-      // replace recordIfExpired: false with expiryStrategy: warn
-      mergedConfig.expiryStrategy = EXPIRY_STRATEGIES.WARN;
-    }
-
-    delete mergedConfig.recordIfExpired;
-  }
-
-  return mergedConfig;
-}
 
 function customizer(objValue, srcValue, key) {
   // Arrays and `context` options should just replace the existing value
@@ -30,7 +9,5 @@ function customizer(objValue, srcValue, key) {
 }
 
 export default function mergeConfigs(...configs) {
-  const mergedConfig = mergeWith({}, ...configs, customizer);
-
-  return deprecateRecordIfExpired(mergedConfig);
+  return mergeWith({}, ...configs, customizer);
 }

--- a/tests/integration/adapter-tests.js
+++ b/tests/integration/adapter-tests.js
@@ -254,16 +254,6 @@ export default function adapterTests() {
       await this.polly.persister.delete(this.polly.recordingId);
     });
 
-    it('re-records on expired recording if recordIfExpired is true', async function() {
-      this.polly.configure({ recordIfExpired: true });
-      expect(await testExpiration.call(this)).to.equal(true);
-    });
-
-    it('replays the expired recording if recordIfExpired is false', async function() {
-      this.polly.configure({ recordIfExpired: false });
-      expect(await testExpiration.call(this)).to.equal(false);
-    });
-
     it('warns and plays back on expired recording if expiryStrategy is "warn"', async function() {
       this.polly.configure({ expiryStrategy: 'warn' });
       expect(await testExpiration.call(this)).to.equal(false);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The `recordIfExpired` option has been expired for a while now and since we're about to release a new major version, this is a good time to remove it altogether.

## Types of Changes

<!---
  What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!---
  Go over all the following points, and put an `x` in all the boxes that apply.

  If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have added tests to cover my changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] My code follows the code style of this project.
- [x] My commits and the title of this PR follow the [Conventional Commits Specification](https://www.conventionalcommits.org).
- [x] I have read the [contributing guidelines](https://github.com/Netflix/pollyjs/blob/master/CONTRIBUTING.md).
