### PR TITLE
docs: Team page link fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Thank you to all contributors especially the maintainers: [trek](https://github.
 
 ## We're hiring!
 
-Join the Netflix Studio UI team to help us build projects like this! You can check out our open roles here on our [team page](https://jobs.netflix.com/teams/client-applications).
+Join the Netflix Studio UI team to help us build projects like this! You can check out our open roles here on our [team page](https://jobs.netflix.com/teams/client-and-ui-engineering).
 
 ## License
 


### PR DESCRIPTION
The link to the "team page" is broken https://jobs.netflix.com/teams/client-applications
it seems that the new link is https://jobs.netflix.com/teams/client-and-ui-engineering

<!--- Provide a general summary of your changes in the Title above -->

## Description
I checked the Netflix jobs site for the correct link to the Client / UI team

<!--- Describe your changes in detail -->

## Motivation and Context
The link to the team page at the Netflix jobs subdomain was giving 404
<!---
  Why is this change required? What problem does it solve?

  If it fixes an open issue, please link to the issue here.
-->

## Types of Changes

<!---
  What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!---
  Go over all the following points, and put an `x` in all the boxes that apply.

  If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My code follows the code style of this project.
- [x] My commits and the title of this PR follow the [Conventional Commits Specification](https://www.conventionalcommits.org).
- [x] I have read the [contributing guidelines](https://github.com/Netflix/pollyjs/blob/master/CONTRIBUTING.md).
