### PR TITLE
Fix parsing JSON hexadecimal strings

### DIFF
--- a/packages/@pollyjs/adapter-node-http/src/index.js
+++ b/packages/@pollyjs/adapter-node-http/src/index.js
@@ -7,14 +7,14 @@ import nock from 'nock';
 import {
   normalizeClientRequestArgs,
   isUtf8Representable,
-  isContentEncoded,
-  isJSONContent
+  isContentEncoded
 } from 'nock/lib/common';
 import Adapter from '@pollyjs/adapter';
 import { HTTP_METHODS } from '@pollyjs/utils';
 
 import getUrlFromOptions from './utils/get-url-from-options';
 import mergeChunks from './utils/merge-chunks';
+import { parseBody } from './utils/request-body';
 import urlToOptions from './utils/url-to-options';
 
 const IS_STUBBED = Symbol();
@@ -71,20 +71,7 @@ export default class HttpAdapter extends Adapter {
         );
         const url = getUrlFromOptions(parsedArguments.options);
 
-        if (body) {
-          if (
-            typeof body === 'string' &&
-            !isUtf8Representable(Buffer.from(body, 'hex'))
-          ) {
-            // Nock internally converts a binary buffer into its hexadecimal
-            // representation so convert it back to a buffer.
-            body = Buffer.from(body, 'hex');
-          } else if (isJSONContent(headers)) {
-            // Nock will parse json content into an object. We have our own way
-            // of dealing with json content so convert it back to a string.
-            body = JSON.stringify(body);
-          }
-        }
+        body = parseBody(body, headers);
 
         adapter.handleRequest({
           url,

--- a/packages/@pollyjs/adapter-node-http/src/utils/request-body.js
+++ b/packages/@pollyjs/adapter-node-http/src/utils/request-body.js
@@ -2,17 +2,17 @@ import { isUtf8Representable, isJSONContent } from 'nock/lib/common';
 
 export function parseBody(body, headers) {
   if (body) {
-    if (
+    if (isJSONContent(headers)) {
+      // Nock will parse json content into an object. We have our own way
+      // of dealing with json content so convert it back to a string.
+      return JSON.stringify(body);
+    } else if (
       typeof body === 'string' &&
       !isUtf8Representable(Buffer.from(body, 'hex'))
     ) {
       // Nock internally converts a binary buffer into its hexadecimal
       // representation so convert it back to a buffer.
       return Buffer.from(body, 'hex');
-    } else if (isJSONContent(headers)) {
-      // Nock will parse json content into an object. We have our own way
-      // of dealing with json content so convert it back to a string.
-      return JSON.stringify(body);
     }
   }
   return body;

--- a/packages/@pollyjs/adapter-node-http/src/utils/request-body.js
+++ b/packages/@pollyjs/adapter-node-http/src/utils/request-body.js
@@ -1,19 +1,22 @@
 import { isUtf8Representable, isJSONContent } from 'nock/lib/common';
 
 export function parseBody(body, headers) {
-  if (body) {
-    if (isJSONContent(headers)) {
-      // Nock automatically parses json content, but we have our own way
-      // of dealing with json content, so convert it back to a string.
-      return JSON.stringify(body);
-    } else if (
-      typeof body === 'string' &&
-      !isUtf8Representable(Buffer.from(body, 'hex'))
-    ) {
-      // Nock automatically converts a binary buffer into its hexadecimal
-      // representation so convert it back to a buffer.
-      return Buffer.from(body, 'hex');
-    }
+  if (body === null || body === undefined) {
+    return body;
   }
+
+  if (isJSONContent(headers)) {
+    // Nock automatically parses json content, but we have our own way
+    // of dealing with json content, so convert it back to a string.
+    return JSON.stringify(body);
+  } else if (
+    typeof body === 'string' &&
+    !isUtf8Representable(Buffer.from(body, 'hex'))
+  ) {
+    // Nock automatically converts a binary buffer into its hexadecimal
+    // representation so convert it back to a buffer.
+    return Buffer.from(body, 'hex');
+  }
+
   return body;
 }

--- a/packages/@pollyjs/adapter-node-http/src/utils/request-body.js
+++ b/packages/@pollyjs/adapter-node-http/src/utils/request-body.js
@@ -9,7 +9,9 @@ export function parseBody(body, headers) {
     // Nock automatically parses json content, but we have our own way
     // of dealing with json content, so convert it back to a string.
     return JSON.stringify(body);
-  } else if (
+  }
+
+  if (
     typeof body === 'string' &&
     !isUtf8Representable(Buffer.from(body, 'hex'))
   ) {

--- a/packages/@pollyjs/adapter-node-http/src/utils/request-body.js
+++ b/packages/@pollyjs/adapter-node-http/src/utils/request-body.js
@@ -3,14 +3,14 @@ import { isUtf8Representable, isJSONContent } from 'nock/lib/common';
 export function parseBody(body, headers) {
   if (body) {
     if (isJSONContent(headers)) {
-      // Nock will parse json content into an object. We have our own way
-      // of dealing with json content so convert it back to a string.
+      // Nock automatically parses json content, but we have our own way
+      // of dealing with json content, so convert it back to a string.
       return JSON.stringify(body);
     } else if (
       typeof body === 'string' &&
       !isUtf8Representable(Buffer.from(body, 'hex'))
     ) {
-      // Nock internally converts a binary buffer into its hexadecimal
+      // Nock automatically converts a binary buffer into its hexadecimal
       // representation so convert it back to a buffer.
       return Buffer.from(body, 'hex');
     }

--- a/packages/@pollyjs/adapter-node-http/src/utils/request-body.js
+++ b/packages/@pollyjs/adapter-node-http/src/utils/request-body.js
@@ -1,0 +1,19 @@
+import { isUtf8Representable, isJSONContent } from 'nock/lib/common';
+
+export function parseBody(body, headers) {
+  if (body) {
+    if (
+      typeof body === 'string' &&
+      !isUtf8Representable(Buffer.from(body, 'hex'))
+    ) {
+      // Nock internally converts a binary buffer into its hexadecimal
+      // representation so convert it back to a buffer.
+      return Buffer.from(body, 'hex');
+    } else if (isJSONContent(headers)) {
+      // Nock will parse json content into an object. We have our own way
+      // of dealing with json content so convert it back to a string.
+      return JSON.stringify(body);
+    }
+  }
+  return body;
+}

--- a/packages/@pollyjs/adapter-node-http/tests/unit/utils/request-body-test.js
+++ b/packages/@pollyjs/adapter-node-http/tests/unit/utils/request-body-test.js
@@ -1,0 +1,49 @@
+import { parseBody } from '../../../src/utils/request-body';
+
+const emptyHeaders = {};
+const jsonHeaders = { 'content-type': 'application/json' };
+
+describe('Unit | Utils | parseBody', function() {
+  describe('Nullish values', function() {
+    const nullValues = [null, undefined];
+
+    nullValues.forEach(function(v) {
+      it(`should leave ${v} unmodified`, function() {
+        expect(parseBody(v, emptyHeaders)).to.equal(v);
+      });
+    });
+  });
+
+  describe('JSON values', function() {
+    const jsonValues = [
+      true,
+      false,
+      100,
+      'abc',
+      [1, 'abc'],
+      { a: 1, b: 'abc' }
+    ];
+
+    jsonValues.forEach(function(v) {
+      it(`should stringify ${v}`, function() {
+        expect(parseBody(v, jsonHeaders)).to.equal(JSON.stringify(v));
+      });
+    });
+  });
+
+  describe('Buffer values', function() {
+    const bufferValues = [Buffer.from([171]), Buffer.from([300, 200])];
+
+    bufferValues.forEach(function(buffer) {
+      const hex = buffer.toString('hex');
+
+      it(`should parse ${hex} as a buffer`, function() {
+        const result = parseBody(hex, emptyHeaders);
+
+        for (let i = 0; i < result.length; i++) {
+          expect(result[i]).to.equal(buffer[i]);
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix parsing JSON strings that look like hexadecimal Buffer streams

## Motivation and Context

I was having an issue where Polly was intercepting my JSON payload, the string `"AdministerDb"`, and turning it into a Buffer `<Buffer ad>`. The problem is that `Buffer.from('AdministerDb', 'hex')` parses as much hex as possible, in this case `Ad`, and treating it as a hexadecimal Buffer stream.

To fix this, I made sure to handle JSON values before handling buffer. I'm making the assumption that no one would be sending binary data with `Content-Type: application/json`, but I think it's a valid assumption. I also added tests and found that the JSON value `false` wasn't being stringified either.

## Types of Changes

<!---
  What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!---
  Go over all the following points, and put an `x` in all the boxes that apply.

  If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] My code follows the code style of this project.
- [x] My commits and the title of this PR follow the [Conventional Commits Specification](https://www.conventionalcommits.org).
- [ ] I have read the [contributing guidelines](https://github.com/Netflix/pollyjs/blob/master/CONTRIBUTING.md).
