### PR TITLE
feat(persister): Add `disableSortingHarEntries` option

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -241,6 +241,25 @@ polly.configure({
 });
 ```
 
+### disableSortingHarEntries
+
+_Type_: `Boolean`
+_Default_: `false`
+
+When disabled, entries in the the final HAR will be sorted by the request's timestamp.
+This is done by default to satisfy the HAR 1.2 spec but can be enabled to improve
+diff readability when committing recordings to git.
+
+**Example**
+
+```js
+polly.configure({
+  persisterOptions: {
+    disableSortingHarEntries: true
+  }
+});
+```
+
 ## timing
 
 _Type_: `Function`

--- a/packages/@pollyjs/core/src/defaults/config.js
+++ b/packages/@pollyjs/core/src/defaults/config.js
@@ -11,7 +11,7 @@ export default {
   persister: null,
   persisterOptions: {
     keepUnusedRequests: false,
-    disableSortingHarEntries: true
+    disableSortingHarEntries: false
   },
 
   logging: false,

--- a/packages/@pollyjs/core/src/defaults/config.js
+++ b/packages/@pollyjs/core/src/defaults/config.js
@@ -10,7 +10,8 @@ export default {
 
   persister: null,
   persisterOptions: {
-    keepUnusedRequests: false
+    keepUnusedRequests: false,
+    disableSortingHarEntries: true
   },
 
   logging: false,

--- a/packages/@pollyjs/persister/src/har/log.js
+++ b/packages/@pollyjs/persister/src/har/log.js
@@ -34,8 +34,6 @@ export default class Log {
       [...entries, ...this.entries],
       (a, b) => a._id === b._id && a._order === b._order
     );
-
-    this.sortEntries();
   }
 
   sortEntries() {

--- a/packages/@pollyjs/persister/src/index.js
+++ b/packages/@pollyjs/persister/src/index.js
@@ -87,6 +87,10 @@ export default class Persister {
 
       har.log.addEntries(entries);
 
+      if (!this.polly.config.persisterOptions.disableSortingHarEntries) {
+        har.log.sortEntries();
+      }
+
       if (!this.polly.config.persisterOptions.keepUnusedRequests) {
         this._removeUnusedEntries(recordingId, har);
       }

--- a/packages/@pollyjs/persister/tests/unit/har-test.js
+++ b/packages/@pollyjs/persister/tests/unit/har-test.js
@@ -34,7 +34,7 @@ describe('Unit | HAR', function() {
       ).to.be.true;
     });
 
-    it('addEntries: Entries should be unique & sorted', async function() {
+    it('addEntries: Entries should be unique', async function() {
       const now = new Date().getTime();
       const log = new Log({
         entries: [
@@ -72,10 +72,10 @@ describe('Unit | HAR', function() {
       expect(
         log.entries.map(({ _id, _order, _new }) => ({ _id, _order, _new }))
       ).to.include.deep.ordered.members([
-        { _id: 'ghi', _order: 0, _new: true },
-        { _id: 'def', _order: 0, _new: false },
         { _id: 'abc', _order: 0, _new: true },
-        { _id: 'abc', _order: 1, _new: true }
+        { _id: 'abc', _order: 1, _new: true },
+        { _id: 'ghi', _order: 0, _new: true },
+        { _id: 'def', _order: 0, _new: false }
       ]);
     });
 

--- a/tests/integration/persister-tests.js
+++ b/tests/integration/persister-tests.js
@@ -264,4 +264,85 @@ export default function persisterTests() {
     expect(har.log.entries[0].request.url).to.include(orderedRecordUrl(1));
     expect(har.log.entries[1].request.url).to.include(orderedRecordUrl(3));
   });
+
+  it('should sort the entries by date', async function() {
+    this.polly.configure({
+      persisterOptions: {
+        keepUnusedRequests: true
+      }
+    });
+    const { recordingName, recordingId, config } = this.polly;
+
+    const orderedRecordUrl = order => `${this.recordUrl()}?order=${order}`;
+
+    await this.fetch(orderedRecordUrl(1));
+    await this.fetch(orderedRecordUrl(2));
+    await this.polly.persister.persist();
+
+    let har = await this.polly.persister.find(recordingId);
+
+    expect(har).to.be.an('object');
+    expect(har.log.entries).to.have.lengthOf(2);
+    expect(har.log.entries[0].request.url).to.include(orderedRecordUrl(1));
+    expect(har.log.entries[1].request.url).to.include(orderedRecordUrl(2));
+
+    await this.polly.stop();
+
+    this.polly = new Polly(recordingName, config);
+    this.polly.replay();
+
+    await this.fetch(orderedRecordUrl(3));
+    await this.fetch(orderedRecordUrl(4));
+    await this.polly.persister.persist();
+
+    har = await this.polly.persister.find(recordingId);
+
+    expect(har).to.be.an('object');
+    expect(har.log.entries).to.have.lengthOf(4);
+    expect(har.log.entries[0].request.url).to.include(orderedRecordUrl(1));
+    expect(har.log.entries[1].request.url).to.include(orderedRecordUrl(2));
+    expect(har.log.entries[2].request.url).to.include(orderedRecordUrl(3));
+    expect(har.log.entries[3].request.url).to.include(orderedRecordUrl(4));
+  });
+
+  it('should not sort the entries by date if `disableSortingHarEntries` is true', async function() {
+    this.polly.configure({
+      persisterOptions: {
+        keepUnusedRequests: true,
+        disableSortingHarEntries: true
+      }
+    });
+    const { recordingName, recordingId, config } = this.polly;
+
+    const orderedRecordUrl = order => `${this.recordUrl()}?order=${order}`;
+
+    await this.fetch(orderedRecordUrl(1));
+    await this.fetch(orderedRecordUrl(2));
+    await this.polly.persister.persist();
+
+    let har = await this.polly.persister.find(recordingId);
+
+    expect(har).to.be.an('object');
+    expect(har.log.entries).to.have.lengthOf(2);
+    expect(har.log.entries[0].request.url).to.include(orderedRecordUrl(1));
+    expect(har.log.entries[1].request.url).to.include(orderedRecordUrl(2));
+
+    await this.polly.stop();
+
+    this.polly = new Polly(recordingName, config);
+    this.polly.replay();
+
+    await this.fetch(orderedRecordUrl(3));
+    await this.fetch(orderedRecordUrl(4));
+    await this.polly.persister.persist();
+
+    har = await this.polly.persister.find(recordingId);
+
+    expect(har).to.be.an('object');
+    expect(har.log.entries).to.have.lengthOf(4);
+    expect(har.log.entries[0].request.url).to.include(orderedRecordUrl(3));
+    expect(har.log.entries[1].request.url).to.include(orderedRecordUrl(4));
+    expect(har.log.entries[2].request.url).to.include(orderedRecordUrl(1));
+    expect(har.log.entries[3].request.url).to.include(orderedRecordUrl(2));
+  });
 }

--- a/tests/integration/persister-tests.js
+++ b/tests/integration/persister-tests.js
@@ -289,10 +289,11 @@ export default function persisterTests() {
     await this.polly.stop();
 
     this.polly = new Polly(recordingName, config);
-    this.polly.replay();
+    this.polly.record();
 
     await this.fetch(orderedRecordUrl(3));
     await this.fetch(orderedRecordUrl(4));
+    await this.fetch(orderedRecordUrl(2));
     await this.polly.persister.persist();
 
     har = await this.polly.persister.find(recordingId);
@@ -300,9 +301,9 @@ export default function persisterTests() {
     expect(har).to.be.an('object');
     expect(har.log.entries).to.have.lengthOf(4);
     expect(har.log.entries[0].request.url).to.include(orderedRecordUrl(1));
-    expect(har.log.entries[1].request.url).to.include(orderedRecordUrl(2));
-    expect(har.log.entries[2].request.url).to.include(orderedRecordUrl(3));
-    expect(har.log.entries[3].request.url).to.include(orderedRecordUrl(4));
+    expect(har.log.entries[1].request.url).to.include(orderedRecordUrl(3));
+    expect(har.log.entries[2].request.url).to.include(orderedRecordUrl(4));
+    expect(har.log.entries[3].request.url).to.include(orderedRecordUrl(2));
   });
 
   it('should not sort the entries by date if `disableSortingHarEntries` is true', async function() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When disabled, entries in the the final HAR will be sorted by the request's timestamp.
This is done by default to satisfy the HAR 1.2 spec but can be enabled to improve
diff readability when committing recordings to git.

## Motivation and Context

Related to #269.

## Types of Changes

<!---
  What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!---
  Go over all the following points, and put an `x` in all the boxes that apply.

  If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have added tests to cover my changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] My code follows the code style of this project.
- [x] My commits and the title of this PR follow the [Conventional Commits Specification](https://www.conventionalcommits.org).
- [x] I have read the [contributing guidelines](https://github.com/Netflix/pollyjs/blob/master/CONTRIBUTING.md).
