### PR TITLE
Make Adapter & Persister backwards compatible for implementors

### DIFF
--- a/packages/@pollyjs/adapter/src/index.js
+++ b/packages/@pollyjs/adapter/src/index.js
@@ -23,10 +23,15 @@ export default class Adapter {
     return 'adapter';
   }
 
-  /* eslint-disable-next-line getter-return */
   static get id() {
-    assert('Must override the static `id` getter.');
+    return this.name;
   }
+
+  /* eslint-disable-next-line getter-return */
+  static get name() {
+    assert('Must override the static `name` getter.');
+  }
+
 
   get defaultOptions() {
     return {};

--- a/packages/@pollyjs/adapter/src/index.js
+++ b/packages/@pollyjs/adapter/src/index.js
@@ -27,6 +27,7 @@ export default class Adapter {
     return this.name;
   }
 
+  // NOTE: deprecated in 4.1.0. Remove in 5.0.0
   /* eslint-disable-next-line getter-return */
   static get name() {
     assert('Must override the static `name` getter.');

--- a/packages/@pollyjs/persister/src/index.js
+++ b/packages/@pollyjs/persister/src/index.js
@@ -17,9 +17,14 @@ export default class Persister {
     return 'persister';
   }
 
-  /* eslint-disable-next-line getter-return */
   static get id() {
-    assert('Must override the static `id` getter.');
+    return this.name;
+  }
+
+  // NOTE: deprecated in 4.1.0. Remove in 5.0.0
+  /* eslint-disable-next-line getter-return */
+  static get name() {
+    assert('Must override the static `name` getter.');
   }
 
   get defaultOptions() {


### PR DESCRIPTION
The replacement of the static `name` getter for `Adapter` and `Persister` in #310 broke custom implementations of these classes. To retain backwards compatibility we remove the requirement for `id` to be overridden.

## Motivation and Context

The changes in #310 required implementors of `Adapter` and `Class` to override the static `id` getter. This broke backwards compatibility with existing out-of-tree implementations of these classes—a simple patch upgrade would now throw exceptions.

## Description

To retain backwards compatibility we have `id` delegate to `name` by default. We restore the `name` getter and require an override of the method. This does not affect the in-tree implementations.


## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist


- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] My code follows the code style of this project.
- [x] My commits and the title of this PR follow the [Conventional Commits Specification](https://www.conventionalcommits.org).
- [x] I have read the [contributing guidelines](https://github.com/Netflix/pollyjs/blob/master/CONTRIBUTING.md).