### PR TITLE
fix(adapter-node-http): Improve binary response body handling

### DIFF
--- a/packages/@pollyjs/adapter/src/utils/normalize-recorded-response.js
+++ b/packages/@pollyjs/adapter/src/utils/normalize-recorded-response.js
@@ -7,7 +7,8 @@ export default function normalizeRecordedResponse(response) {
     statusText,
     statusCode: status,
     headers: normalizeHeaders(headers),
-    body: content && content.text
+    body: content && content.text,
+    isBinary: Boolean(content && content._isBinary)
   };
 }
 

--- a/packages/@pollyjs/core/src/-private/request.js
+++ b/packages/@pollyjs/core/src/-private/request.js
@@ -172,7 +172,7 @@ export default class PollyRequest extends HTTPBase {
   }
 
   async respond(response) {
-    const { statusCode, headers, body } = response || {};
+    const { statusCode, headers, body, isBinary = false } = response || {};
 
     assert(
       'Cannot respond to a request that already has a response.',
@@ -194,6 +194,8 @@ export default class PollyRequest extends HTTPBase {
 
     // Set the body without modifying any headers (instead of using .send())
     this.response.body = body;
+
+    this.response.isBinary = isBinary;
 
     // Trigger the `beforeResponse` event
     await this._emit('beforeResponse', this.response);

--- a/packages/@pollyjs/core/src/-private/response.js
+++ b/packages/@pollyjs/core/src/-private/response.js
@@ -5,12 +5,12 @@ import HTTPBase from './http-base';
 const DEFAULT_STATUS_CODE = 200;
 
 export default class PollyResponse extends HTTPBase {
-  constructor(statusCode, headers, body) {
+  constructor(statusCode, headers, body, isBinary = false) {
     super();
     this.status(statusCode || DEFAULT_STATUS_CODE);
     this.setHeaders(headers);
     this.body = body;
-    this.isBinary = false;
+    this.isBinary = isBinary;
   }
 
   get ok() {

--- a/packages/@pollyjs/core/src/-private/response.js
+++ b/packages/@pollyjs/core/src/-private/response.js
@@ -10,6 +10,7 @@ export default class PollyResponse extends HTTPBase {
     this.status(statusCode || DEFAULT_STATUS_CODE);
     this.setHeaders(headers);
     this.body = body;
+    this.isBinary = false;
   }
 
   get ok() {

--- a/packages/@pollyjs/core/tests/unit/-private/response-test.js
+++ b/packages/@pollyjs/core/tests/unit/-private/response-test.js
@@ -14,6 +14,10 @@ describe('Unit | Response', function() {
     expect(new PollyResponse().statusCode).to.equal(200);
   });
 
+  it('should default isBinary to false', function() {
+    expect(new PollyResponse().isBinary).to.be.false;
+  });
+
   describe('API', function() {
     beforeEach(function() {
       response = new PollyResponse();

--- a/packages/@pollyjs/persister/src/har/response.js
+++ b/packages/@pollyjs/persister/src/har/response.js
@@ -37,6 +37,10 @@ export default class Response {
 
     if (response.body && typeof response.body === 'string') {
       this.content.text = response.body;
+
+      if (response.isBinary) {
+        this.content._isBinary = true;
+      }
     }
 
     const contentLength = getFirstHeader(response, 'Content-Length');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The core issue was in `getChunksFromBody` where we pass it the recorded body and response headers. Since the body is a string, it can't really know if the original buffer was binary or not. To get around that, we now store whether the response content is binary or not in the HAR file and expose it via the response class.

## Motivation and Context

<!---
  Why is this change required? What problem does it solve?

  If it fixes an open issue, please link to the issue here.
-->

Resolves #327.

## Types of Changes

<!---
  What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!---
  Go over all the following points, and put an `x` in all the boxes that apply.

  If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] My code follows the code style of this project.
- [x] My commits and the title of this PR follow the [Conventional Commits Specification](https://www.conventionalcommits.org).
- [x] I have read the [contributing guidelines](https://github.com/Netflix/pollyjs/blob/master/CONTRIBUTING.md).
