### PR TITLE
feat(core): Add `flushRequestsOnStop` configuration option

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,6 +71,22 @@ polly.configure({
 });
 ```
 
+## flushRequestsOnStop
+
+_Type_: `Boolean`
+_Default_: `false`
+
+Await any unresolved requests handled by the polly instance
+(via [flush](api#flush)) when [stop](api#stop) is called.
+
+**Example**
+
+```js
+polly.configure({
+  flushRequestsOnStop: true
+});
+```
+
 ## expiresIn
 
 _Type_: `String`

--- a/packages/@pollyjs/core/src/defaults/config.js
+++ b/packages/@pollyjs/core/src/defaults/config.js
@@ -15,6 +15,7 @@ export default {
   },
 
   logging: false,
+  flushRequestsOnStop: false,
 
   recordIfMissing: true,
   recordFailedRequests: false,

--- a/packages/@pollyjs/core/src/polly.js
+++ b/packages/@pollyjs/core/src/polly.js
@@ -232,6 +232,10 @@ export default class Polly {
    */
   async stop() {
     if (this.mode !== MODES.STOPPED) {
+      if (this.config.flushRequestsOnStop) {
+        await this.flush();
+      }
+
       this.disconnect();
       this.logger.disconnect();
       await (this.persister && this.persister.persist());

--- a/packages/@pollyjs/core/tests/unit/polly-test.js
+++ b/packages/@pollyjs/core/tests/unit/polly-test.js
@@ -169,6 +169,28 @@ describe('Unit | Polly', function() {
     expect(recognizedOptions.context).to.equal(fakeContext);
   });
 
+  it('calls flush when flushRequestsOnStop is enabled', async function() {
+    let polly = new Polly('squawk', { flushRequestsOnStop: false });
+    let flushCalled = false;
+
+    polly.flush = async () => {
+      flushCalled = true;
+    };
+
+    await polly.stop();
+    expect(flushCalled).to.be.false;
+
+    polly = new Polly('squawk', { flushRequestsOnStop: true });
+    flushCalled = false;
+
+    polly.flush = async () => {
+      flushCalled = true;
+    };
+
+    await polly.stop();
+    expect(flushCalled).to.be.true;
+  });
+
   describe('configure', function() {
     setupPolly();
 
@@ -480,6 +502,13 @@ describe('Unit | Polly', function() {
       expect(disconnects.length).to.equal(0);
       expect(this.polly.disconnect());
       expect(disconnects.length).to.equal(2);
+    });
+
+    it('.flush()', async function() {
+      const promise = this.polly.flush();
+
+      expect(promise).to.be.a('promise');
+      await promise;
     });
   });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This gives you the ability to call `polly.flush()` when the instance is stopped via a configuration option.

## Motivation and Context

I've noticed a few libraries using `afterEach` hooks (or something similar) to call `flush` before the instance is stopped. This should hopefully make it a lot simpler.

## Types of Changes

<!---
  What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!---
  Go over all the following points, and put an `x` in all the boxes that apply.

  If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have added tests to cover my changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] My code follows the code style of this project.
- [x] My commits and the title of this PR follow the [Conventional Commits Specification](https://www.conventionalcommits.org).
- [x] I have read the [contributing guidelines](https://github.com/Netflix/pollyjs/blob/master/CONTRIBUTING.md).
