### PR TITLE
fix(adapter-fetch): Add statusText to the response

### DIFF
--- a/docs/adapters/custom.md
+++ b/docs/adapters/custom.md
@@ -93,6 +93,7 @@ class FetchAdapter extends Adapter {
 
       return new Response(response.body, {
         status: response.statusCode,
+        statusText: response.statusText,
         headers: response.headers
       });
     };

--- a/packages/@pollyjs/adapter-fetch/src/index.js
+++ b/packages/@pollyjs/adapter-fetch/src/index.js
@@ -218,6 +218,7 @@ export default class FetchAdapter extends Adapter {
 
     const response = new Response(responseBody, {
       status: statusCode,
+      statusText: pollyResponse.statusText,
       headers: pollyResponse.headers
     });
 

--- a/packages/@pollyjs/adapter-fetch/tests/integration/adapter-test.js
+++ b/packages/@pollyjs/adapter-fetch/tests/integration/adapter-test.js
@@ -133,6 +133,16 @@ describe('Integration | Fetch Adapter', function() {
     expect(nativeResponseBuffer.equals(replayedResponseBuffer)).to.equal(true);
   });
 
+  it('should return status text', async function() {
+    const { server } = this.polly;
+
+    server.any(this.recordUrl()).intercept((_, res) => res.sendStatus(200));
+
+    const res = await this.fetch(new Request(this.recordUrl()));
+
+    expect(res.statusText).to.equal('OK');
+  });
+
   describe('Request', function() {
     it('should support Request objects', async function() {
       const { server } = this.polly;

--- a/packages/@pollyjs/adapter-fetch/tests/integration/server-test.js
+++ b/packages/@pollyjs/adapter-fetch/tests/integration/server-test.js
@@ -23,6 +23,7 @@ describe('Integration | Server', function() {
     const json = await res.json();
 
     expect(res.status).to.equal(200);
+    expect(res.statusText).to.equal('OK');
     expect(res.headers.get('x-foo')).to.equal('bar');
     expect(json).to.deep.equal({ foo: 'bar' });
   });

--- a/packages/@pollyjs/adapter-fetch/tests/integration/server-test.js
+++ b/packages/@pollyjs/adapter-fetch/tests/integration/server-test.js
@@ -23,7 +23,6 @@ describe('Integration | Server', function() {
     const json = await res.json();
 
     expect(res.status).to.equal(200);
-    expect(res.statusText).to.equal('OK');
     expect(res.headers.get('x-foo')).to.equal('bar');
     expect(json).to.deep.equal({ foo: 'bar' });
   });


### PR DESCRIPTION
## Description

Adds the property `statusText` to the response returned by `fetch`.

## Motivation and Context

The `Response` object created by the `fetch-adapter` may return more info, this could be useful to simulare a real request to the server.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have added tests to cover my changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] My code follows the code style of this project.
- [x] My commits and the title of this PR follow the [Conventional Commits Specification](https://www.conventionalcommits.org).
- [x] I have read the [contributing guidelines](https://github.com/Netflix/pollyjs/blob/master/CONTRIBUTING.md).
