### PR TITLE
fix(core): Compute order based on id and recording name

### DIFF
--- a/packages/@pollyjs/core/src/-private/request.js
+++ b/packages/@pollyjs/core/src/-private/request.js
@@ -265,13 +265,14 @@ export default class PollyRequest extends HTTPBase {
     // Guid is a string representation of the identifiers
     this.id = md5(stringify(this.identifiers));
 
-    // Order is calculated on other requests with the same id
+    // Order is calculated on other requests with the same id and recording id
     // Only requests before this current one are taken into account.
     this.order =
       matchRequestsBy.order && !this.shouldPassthrough && !this.shouldIntercept
         ? requests
             .slice(0, requests.indexOf(this))
-            .filter(r => r.id === this.id).length
+            .filter(r => r.id === this.id && r.recordingId === this.recordingId)
+            .length
         : 0;
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Compute the request's order based on its id as well as the recording id it will be accessed from.

## Motivation and Context

Resolves #340.

<!---
  Why is this change required? What problem does it solve?

  If it fixes an open issue, please link to the issue here.
-->

## Types of Changes

<!---
  What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!---
  Go over all the following points, and put an `x` in all the boxes that apply.

  If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] My code follows the code style of this project.
- [x] My commits and the title of this PR follow the [Conventional Commits Specification](https://www.conventionalcommits.org).
- [x] I have read the [contributing guidelines](https://github.com/Netflix/pollyjs/blob/master/CONTRIBUTING.md).
