### PR TITLE
docs: Typo in interceptor.stopPropagation

### DIFF
--- a/docs/server/route-handler.md
+++ b/docs/server/route-handler.md
@@ -189,9 +189,9 @@ server.delete('/session/:id').intercept((req, res) => res.sendStatus(204));
 // Second call should 404 since the user no longer exists
 server.get('/session/:id').intercept((req, res) => res.sendStatus(404));
 
-await fetch('/users/1'); // --> 200
-await fetch('/users/1', { method: 'DELETE' }); // --> 204
-await fetch('/users/1'); // --> 404
+await fetch('/session/1'); // --> 200
+await fetch('/session/1', { method: 'DELETE' }); // --> 204
+await fetch('/session/1'); // --> 404
 ```
 
 ### passthrough


### PR DESCRIPTION
[Online doc](https://netflix.github.io/pollyjs/#/server/route-handler?id=stoppropagation)

In above link , the example usage of interceptor.stopPropagation has typo 

It mocking `/session/:id` but fetching `/users/:id`

## Motivation and Context

Fix the typo and make the example work

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] My code follows the code style of this project.
- [ ] My commits and the title of this PR follow the [Conventional Commits Specification](https://www.conventionalcommits.org).
- [x] I have read the [contributing guidelines](https://github.com/Netflix/pollyjs/blob/master/CONTRIBUTING.md).
