### PR TITLE
fix(adapter-xhr): Only modify the `responseType` if it was changed

### DIFF
--- a/packages/@pollyjs/adapter-xhr/src/index.js
+++ b/packages/@pollyjs/adapter-xhr/src/index.js
@@ -91,9 +91,10 @@ export default class XHRAdapter extends Adapter {
     );
 
     xhr.async = fakeXhr.async;
-    xhr.responseType = BINARY_RESPONSE_TYPES.includes(fakeXhr.responseType)
-      ? 'arraybuffer'
-      : 'text';
+
+    if (BINARY_RESPONSE_TYPES.includes(fakeXhr.responseType)) {
+      xhr.responseType = 'arraybuffer';
+    }
 
     if (fakeXhr.async) {
       xhr.timeout = fakeXhr.timeout;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Modifying the `responseType` for synchronous requests is not allowed. Since we really just need to override `blob` or `arraybuffer` to `arraybuffer` and not default it to `text`, I moved the logic into an if statement which should naturally add support back to synchronous requests.

## Motivation and Context

<!---
  Why is this change required? What problem does it solve?

  If it fixes an open issue, please link to the issue here.
-->

Resolves #356.

## Types of Changes

<!---
  What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!---
  Go over all the following points, and put an `x` in all the boxes that apply.

  If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] My code follows the code style of this project.
- [x] My commits and the title of this PR follow the [Conventional Commits Specification](https://www.conventionalcommits.org).
- [x] I have read the [contributing guidelines](https://github.com/Netflix/pollyjs/blob/master/CONTRIBUTING.md).
