### PR TITLE
chore(core): Slient error logging if logging is false

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,7 +28,11 @@ polly.configure({
 _Type_: `Boolean`
 _Default_: `false`
 
-Logs requests and their responses to the console grouped by the recording name.
+Flags control logs appear to console grouped by the recording name.
+it includes
+
+- Request/Response log
+- Error log like `Record Not Found`, `Request error...etc.`
 
 **Example**
 

--- a/packages/@pollyjs/core/src/-private/logger.js
+++ b/packages/@pollyjs/core/src/-private/logger.js
@@ -65,17 +65,16 @@ export default class Logger {
   }
 
   logError(request, error) {
-    this.groupStart(request.recordingName);
-
-    console.group(`Errored ➞ ${request.method} ${request.url}`);
-    console.error(error);
-    console.log('Request:', request);
-
-    if (request.didRespond) {
-      console.log('Response:', request.response);
+    if (request.config.logging) {
+      this.groupStart(request.recordingName);
+      console.group(`Errored ➞ ${request.method} ${request.url}`);
+      console.error(error);
+      console.log('Request:', request);
+      if (request.didRespond) {
+        console.log('Response:', request.response);
+      }
+      console.log('Identifiers:', request.identifiers);
+      console.groupEnd();
     }
-
-    console.log('Identifiers:', request.identifiers);
-    console.groupEnd();
   }
 }


### PR DESCRIPTION
## Description

When polly with `replay` mode running on jest with react environment, it print a lot message like `Record not found` , `ECONNREFUSED` ...etc.

most of them is not helpful coz my test exception still pass

<!--- Describe your changes in detail -->

## Motivation and Context

Polly Config has exposed `logging: boolean` config to controller logging request or not , and when kind of `error` in Polly is no way to disable the log.

<!---
  Why is this change required? What problem does it solve?

  If it fixes an open issue, please link to the issue here.
-->
PR here change `logger` to respect `logging` config to control print log or not. 

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!---
  Go over all the following points, and put an `x` in all the boxes that apply.

  If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have added tests to cover my changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] My code follows the code style of this project.
- [x] My commits and the title of this PR follow the [Conventional Commits Specification](https://www.conventionalcommits.org).
- [x] I have read the [contributing guidelines](https://github.com/Netflix/pollyjs/blob/master/CONTRIBUTING.md).
