### PR TITLE
fix: Upgrade url-parse version to 1.5.1+ to fix CVE-2021-27515 #380

### DIFF
--- a/packages/@pollyjs/core/tests/unit/utils/normalize-request-test.js
+++ b/packages/@pollyjs/core/tests/unit/utils/normalize-request-test.js
@@ -144,9 +144,9 @@ describe('Unit | Utils | Normalize Request', function() {
         [
           'protocol',
           'http://protocol-test.com',
-          [true, 'http://protocol-test.com'],
-          [false, '//protocol-test.com'],
-          [p => p.replace('http', 'https'), 'https://protocol-test.com']
+          [true, 'http://protocol-test.com/'],
+          [false, '//protocol-test.com/'],
+          [p => p.replace('http', 'https'), 'https://protocol-test.com/']
         ],
         [
           'query',
@@ -196,7 +196,7 @@ describe('Unit | Utils | Normalize Request', function() {
 
     it('should support a custom fn', function() {
       expect(url('https://foo.bar', url => url.replace('bar', 'foo'))).to.equal(
-        'https://foo.foo'
+        'https://foo.foo/'
       );
     });
 
@@ -206,7 +206,7 @@ describe('Unit | Utils | Normalize Request', function() {
       url(
         'https://foo.bar',
         (url, request) => {
-          expect(url).to.deep.equal('https://foo.bar');
+          expect(url).to.deep.equal('https://foo.bar/');
           expect(request).to.equal(req);
 
           return url;

--- a/packages/@pollyjs/core/tests/unit/utils/normalize-request-test.js
+++ b/packages/@pollyjs/core/tests/unit/utils/normalize-request-test.js
@@ -120,7 +120,7 @@ describe('Unit | Utils | Normalize Request', function() {
   describe('url', function() {
     it('should sort query params', function() {
       expect(url('http://foo.com?b=1&c=1&a=1', {})).to.equal(
-        'http://foo.com?a=1&b=1&c=1'
+        'http://foo.com/?a=1&b=1&c=1'
       );
     });
 
@@ -132,13 +132,13 @@ describe('Unit | Utils | Normalize Request', function() {
           /* input url */
           'http://hash-test.com?b=1&c=1&a=1#hello=world',
           /* expected when true */
-          [true, 'http://hash-test.com?a=1&b=1&c=1#hello=world'],
+          [true, 'http://hash-test.com/?a=1&b=1&c=1#hello=world'],
           /* expected when false */
-          [false, 'http://hash-test.com?a=1&b=1&c=1'],
+          [false, 'http://hash-test.com/?a=1&b=1&c=1'],
           /* expected when custom fn */
           [
             h => h.replace('=', '!='),
-            'http://hash-test.com?a=1&b=1&c=1#hello!=world'
+            'http://hash-test.com/?a=1&b=1&c=1#hello!=world'
           ]
         ],
         [
@@ -151,9 +151,9 @@ describe('Unit | Utils | Normalize Request', function() {
         [
           'query',
           'http://query-test.com?b=1&c=1&a=1',
-          [true, 'http://query-test.com?a=1&b=1&c=1'],
+          [true, 'http://query-test.com/?a=1&b=1&c=1'],
           [false, 'http://query-test.com'],
-          [q => ({ ...q, c: 2 }), 'http://query-test.com?a=1&b=1&c=2']
+          [q => ({ ...q, c: 2 }), 'http://query-test.com/?a=1&b=1&c=2']
         ],
         [
           'username',

--- a/packages/@pollyjs/utils/package.json
+++ b/packages/@pollyjs/utils/package.json
@@ -38,7 +38,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "qs": "^6.7.0",
-    "url-parse": "^1.4.7"
+    "url-parse": "^1.5.1"
   },
   "devDependencies": {
     "rollup": "^1.14.6"

--- a/packages/@pollyjs/utils/tests/unit/utils/url-test.js
+++ b/packages/@pollyjs/utils/tests/unit/utils/url-test.js
@@ -9,7 +9,7 @@ describe('Unit | Utils | URL', function() {
   });
 
   it('should work', function() {
-    expect(new URL('http://netflix.com').href).to.equal('http://netflix.com');
+    expect(new URL('http://netflix.com').href).to.equal('http://netflix.com/');
   });
 
   it('should should not parse the query string by default', function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13858,10 +13858,10 @@ url-parse-lax@^3.0.0:
   dependencies:
     prepend-http "^2.0.0"
 
-url-parse@^1.4.7:
-  version "1.4.7"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.7.tgz#a8a83535e8c00a316e403a5db4ac1b9b853ae278"
-  integrity sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==
+url-parse@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.1.tgz#d5fa9890af8a5e1f274a2c98376510f6425f6e3b"
+  integrity sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"


### PR DESCRIPTION
Bump url-parse dependency due to vulnerability in the versions before 1.5.0

## Description

Upgrade url-parse version to 1.5.1+ to fix CVE-2021-27515 #380

## Motivation and Context

* #380
* https://advisories.gitlab.com/advisory/advnpm_url_parse_CVE_2021_27515.html

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] My code follows the code style of this project.
- [x] My commits and the title of this PR follow the [Conventional Commits Specification](https://www.conventionalcommits.org).
- [x] I have read the [contributing guidelines](https://github.com/Netflix/pollyjs/blob/master/CONTRIBUTING.md).
