### PR TITLE
fix: Handle failed arraybuffer instanceof checks

### DIFF
--- a/packages/@pollyjs/utils/src/index.js
+++ b/packages/@pollyjs/utils/src/index.js
@@ -17,3 +17,4 @@ export { default as URL } from './utils/url';
 export {
   default as isBufferUtf8Representable
 } from './utils/is-buffer-utf8-representable';
+export { default as cloneArrayBuffer } from './utils/clone-arraybuffer';

--- a/packages/@pollyjs/utils/src/utils/clone-arraybuffer.js
+++ b/packages/@pollyjs/utils/src/utils/clone-arraybuffer.js
@@ -1,0 +1,12 @@
+/**
+ * Clone an array buffer
+ *
+ * @param {ArrayBuffer} arrayBuffer
+ */
+export default function cloneArrayBuffer(arrayBuffer) {
+  const clonedArrayBuffer = new ArrayBuffer(arrayBuffer.byteLength);
+
+  new Uint8Array(clonedArrayBuffer).set(new Uint8Array(arrayBuffer));
+
+  return clonedArrayBuffer;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When context is provided to both the XHR and Fetch adapters, the arraybuffers that are created by the responses don't pass Buffer.from's instanceof check. To get around that (for now), we clone the ArrayBuffer which uses the same constructor that Buffer.from expects.

## Motivation and Context

Resolves #388.

## Types of Changes

<!---
  What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!---
  Go over all the following points, and put an `x` in all the boxes that apply.

  If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] My code follows the code style of this project.
- [x] My commits and the title of this PR follow the [Conventional Commits Specification](https://www.conventionalcommits.org).
- [x] I have read the [contributing guidelines](https://github.com/Netflix/pollyjs/blob/master/CONTRIBUTING.md).
