### PR TITLE
bump http-graceful-shutdown version

### DIFF
--- a/packages/@pollyjs/node-server/package.json
+++ b/packages/@pollyjs/node-server/package.json
@@ -42,8 +42,8 @@
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "fs-extra": "^8.0.1",
-    "http-graceful-shutdown": "^2.3.1",
-    "morgan": "^1.9.1",
+    "http-graceful-shutdown": "^3.1.4",
+    "morgan": "^1.10.0",
     "nocache": "^2.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

This pull request updates the http-graceful-shutdown dependency version from 2.3.1 to 3.1.4. 

## Motivation and Context

This version is fully backwards compatible to version 2.x but adds much better handling under the hood.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Non breaking change - dependency update - for stabilization reasons

## Checklist

- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] My code follows the code style of this project.
- [x] My commits and the title of this PR follow the [Conventional Commits Specification](https://www.conventionalcommits.org).
- [x] I have read the [contributing guidelines](https://github.com/Netflix/pollyjs/blob/master/CONTRIBUTING.md).
