### PR TITLE
fix(persister): `requests` -> `request` in `HarEntry` declaration

### DIFF
--- a/packages/@pollyjs/persister/types.d.ts
+++ b/packages/@pollyjs/persister/types.d.ts
@@ -39,7 +39,7 @@ export interface HarEntry {
   _id: string;
   _order: number;
   startedDateTime: string;
-  requests: HarRequest;
+  request: HarRequest;
   response: HarResponse;
   cache: {};
   timings: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Fix typo in `HarEntry` type declaration. In reality, [the property is called `request`](https://github.com/Netflix/pollyjs/blob/18262cf3213d3f3ca7a778a574c162dc2318860a/packages/%40pollyjs/persister/src/har/entry.js#L18) but the declaration uses `requests` instead.

## Motivation and Context

<!---
  Why is this change required? What problem does it solve?

  If it fixes an open issue, please link to the issue here.
-->
See above.

In addition to this fix, the declaration is also lacking the `_recordingName` and `creator` properties for `HarLog` instances, but I'm not sure how to best handle these as they are added by the base persister implementation, so it could be possible that a custom persister omits these properties. Perhaps the `HarLog` declaration should be made generic to handle this? Happy to add it to this PR in case that's desired.

## Types of Changes

<!---
  What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!---
  Go over all the following points, and put an `x` in all the boxes that apply.

  If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] My code follows the code style of this project.
- [x] My commits and the title of this PR follow the [Conventional Commits Specification](https://www.conventionalcommits.org).
- [x] I have read the [contributing guidelines](https://github.com/Netflix/pollyjs/blob/master/CONTRIBUTING.md).
