### PR TITLE
fix(node-server): API class type name correction

### DIFF
--- a/packages/@pollyjs/node-server/types.d.ts
+++ b/packages/@pollyjs/node-server/types.d.ts
@@ -23,7 +23,7 @@ export interface APIResponse {
 
 export class API {
   constructor(options: Pick<Config, 'recordingsDir'>);
-  getRecordings(recording: string): APIResponse;
+  getRecording(recording: string): APIResponse;
   saveRecording(recording: string, data: any): APIResponse;
   deleteRecording(recording: string): APIResponse;
   filenameFor(recording: string): string;


### PR DESCRIPTION
## Description

The current API type definition (`getRecordings`) does not match with the actual implementation (`getRecording`).
https://github.com/Netflix/pollyjs/blob/cbca602a5a446da46a4a2834f893670b8c577880/packages/%40pollyjs/node-server/src/api.js#L18

## Motivation and Context

Correct the name so that we can avoid Typescript's compiler error.

`TS2551: Property 'getRecording' does not exist on type 'API'. Did you mean 'getRecordings'?`

## Types of Changes

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] My code follows the code style of this project.
- [x] My commits and the title of this PR follow the [Conventional Commits Specification](https://www.conventionalcommits.org).
- [x] I have read the [contributing guidelines](https://github.com/Netflix/pollyjs/blob/master/CONTRIBUTING.md).
