### PR TITLE
fix: Undeprecating fetch for node because node supports fetch now

### DIFF
--- a/packages/@pollyjs/adapter-fetch/package.json
+++ b/packages/@pollyjs/adapter-fetch/package.json
@@ -44,7 +44,6 @@
   "dependencies": {
     "@pollyjs/adapter": "^6.0.6",
     "@pollyjs/utils": "^6.0.6",
-    "detect-node": "^2.1.0",
     "to-arraybuffer": "^1.0.1"
   },
   "devDependencies": {

--- a/packages/@pollyjs/adapter-fetch/src/index.js
+++ b/packages/@pollyjs/adapter-fetch/src/index.js
@@ -1,6 +1,5 @@
 import Adapter from '@pollyjs/adapter';
 import { cloneArrayBuffer, isBufferUtf8Representable } from '@pollyjs/utils';
-import isNode from 'detect-node';
 import { Buffer } from 'buffer/';
 import bufferToArrayBuffer from 'to-arraybuffer';
 
@@ -24,12 +23,6 @@ export default class FetchAdapter extends Adapter {
 
   onConnect() {
     const { context } = this.options;
-
-    if (isNode) {
-      this.polly.logger.log.warn(
-        '[Polly] [adapter:fetch] Using the fetch adapter in Node has been deprecated. Please use the node-http adapter instead.'
-      );
-    }
 
     ['fetch', 'Request', 'Response', 'Headers'].forEach((key) =>
       this.assert(`${key} global not found.`, !!(context && context[key]))

--- a/yarn.lock
+++ b/yarn.lock
@@ -6980,11 +6980,6 @@ detect-newline@3.1.0, detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-detect-node@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
-  integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
-
 dezalgo@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/dezalgo/-/dezalgo-1.0.3.tgz#7f742de066fc748bc8db820569dddce49bf0d456"


### PR DESCRIPTION
Node natively supports fetch now and the warning is thus unnecessary.

## Description

I've removed the deprecation warning and the dependency on the `detect-node` package.

## Motivation and Context

This change was required because certain API clients lean on Node's `fetch` implementation. Adding PollyJS to the project and configuring it to record Node fetch calls emits a warning unnecessarily.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] My code follows the code style of this project.
- [x] My commits and the title of this PR follow the [Conventional Commits Specification](https://www.conventionalcommits.org).
- [x] I have read the [contributing guidelines](https://github.com/Netflix/pollyjs/blob/master/CONTRIBUTING.md).
